### PR TITLE
[ISSUE #56][FILTERS_VIEW] Add the possibility to mark columns, which …

### DIFF
--- a/dltmessageanalyzerplugin/src/CDLTMessageAnalyzer.cpp
+++ b/dltmessageanalyzerplugin/src/CDLTMessageAnalyzer.cpp
@@ -123,15 +123,6 @@ CDLTMessageAnalyzer::CDLTMessageAnalyzer(const std::weak_ptr<IDLTMessageAnalyzer
 
     mpPatternsTreeView->setPatternsSearchInput(pPatternsSearchInput);
 
-    if(nullptr != mpFiltersView && nullptr != mpRegexLineEdit)
-    {
-        connect( mpFiltersView, &CFiltersView::regexRangeSelectionRequested, this,
-                 [this](const tRange range)
-        {
-            mpRegexLineEdit->setSelection(range.from, range.to - range.from);
-        });
-    }
-
     if( nullptr != mpGroupedResultView &&
             nullptr != mpGroupedViewModel )
     {
@@ -225,14 +216,6 @@ CDLTMessageAnalyzer::CDLTMessageAnalyzer(const std::weak_ptr<IDLTMessageAnalyzer
     if(nullptr != mpFiltersSearchInput)
     {
         connect( mpFiltersSearchInput, &QLineEdit::returnPressed, this, [this](){ analyze(); } );
-    }
-
-    if(nullptr != mpFiltersView && nullptr != mpRegexLineEdit)
-    {
-        connect(mpFiltersView, &CFiltersView::returnPressed, this, [this]()
-        {
-            mpRegexLineEdit->setFocus();
-        });
     }
 
     if(nullptr != mpFiltersModel && nullptr != mpFiltersView)

--- a/dltmessageanalyzerplugin/src/dltmessageanalyzerplugin.cpp
+++ b/dltmessageanalyzerplugin/src/dltmessageanalyzerplugin.cpp
@@ -17,6 +17,7 @@
 #include "settings/CSettingsManager.hpp"
 #include "dltWrappers/CDLTMsgWrapper.hpp"
 #include "patternsView/CPatternsView.hpp"
+#include "filtersView/CFiltersView.hpp"
 
 Q_DECLARE_METATYPE(tDltMsgWrapperPtr)
 
@@ -94,6 +95,11 @@ QWidget* DLTMessageAnalyzerPlugin::initViewer()
 
     auto pMTController = IDLTMessageAnalyzerController::createInstance<CMTAnalyzer>();
     mpMessageAnalyzerController = IDLTMessageAnalyzerController::createInstance<CContinuousAnalyzer>(pMTController);
+
+    if(nullptr != mpForm->getFiltersView())
+    {
+        mpForm->getFiltersView()->setRegexInputField(mpForm->getRegexLineEdit());
+    }
 
     mpDLTMessageAnalyzer = IDLTMessageAnalyzerControllerConsumer::createInstance<CDLTMessageAnalyzer>(mpMessageAnalyzerController,
                                                                                                       mpForm->getGroupedResultView(),

--- a/dltmessageanalyzerplugin/src/filtersView/CFiltersView.hpp
+++ b/dltmessageanalyzerplugin/src/filtersView/CFiltersView.hpp
@@ -20,10 +20,7 @@ public:
 
     void setSpecificModel( CFiltersModel* pModel );
     void highlightInvalidRegex(const QModelIndex &index);
-
-signals:
-    void regexRangeSelectionRequested( const tRange& range );
-    void returnPressed();
+    void setRegexInputField(QLineEdit* pRegexInputField);
 
 protected:
     void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
@@ -34,6 +31,7 @@ private:
     void updateColumnsVisibility();
     void updateWidth();
     void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles = QVector<int>()) override;
+    void copySelectedRowToClipboard();
 
 private: // fields
     CFiltersModel* mpModel;
@@ -50,6 +48,7 @@ private: // fields
     CRegexTreeRepresentationDelegate * mpRepresentationDelegate;
     bool mbResizeOnExpandCollapse;
     bool mbSkipFirstUpdateWidth;
+    QLineEdit* mpRegexInputField;
 };
 
 #endif // CFILTERSVIEW_HPP


### PR DESCRIPTION
[ISSUE #56][FILTERS_VIEW] Add the possibility to mark columns, which should be copied during the copy operation

1. [X] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [X] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [X] Is your change backward-compatible with the previous version of the plugin?

- Refactoring of the connection between CFiltersView and regex line edit
- Addition of "Reset visible columns" context-menu to the filters view
- Addition of the "Copy" context-menu to the filters view

Tested on Linux and Windows