### PR TITLE
[ISSUE #30][GROUPED_VIEW] Add the possibility to mark columns, which should be copied during the copy operation

### DIFF
--- a/dltmessageanalyzerplugin/src/patternsView/CPatternsView.cpp
+++ b/dltmessageanalyzerplugin/src/patternsView/CPatternsView.cpp
@@ -611,7 +611,7 @@ CPatternsView::CPatternsView(QWidget *parent):
 
                             if(foundItem_ != patternsColumnsCopyPasteMap_.end()) // if item is in the map
                             {
-                                foundItem_.value() = checked; // let's update visibility value
+                                foundItem_.value() = checked; // let's update copy paste value
                                 CSettingsManager::getInstance()->setPatternsColumnsCopyPasteMap(patternsColumnsCopyPasteMap_);
                             }
                         });

--- a/dltmessageanalyzerplugin/src/settings/CSettingsManager.cpp
+++ b/dltmessageanalyzerplugin/src/settings/CSettingsManager.cpp
@@ -54,6 +54,7 @@ static const QString sFilterVariablesKey = "FilterVariables";
 static const QString sCaseSensitiveRegex = "caseSensitiveRegex";
 static const QString sSelectedRegexFile = "selectedRegexFile";
 static const QString sGroupedViewColumnsVisibilityMapKey = "GroupedViewColumnsVisibilityMap";
+static const QString sGroupedViewColumnsCopyPasteMapKey = "GroupedViewColumnsCopyPasteMap";
 
 static const tSettingsManagerVersion sDefaultSettingsManagerVersion = static_cast<tSettingsManagerVersion>(-1);
 static const tSettingsManagerVersion sCurrentSettingsManagerVersion = 1u; // current version of settings manager used by SW.
@@ -270,6 +271,10 @@ CSettingsManager::CSettingsManager():
         [this](const tGroupedViewColumnsVisibilityMap& data){groupedViewColumnsVisibilityMapChanged(data);},
         [this](){tryStoreSettingsConfig();},
         sDefaultGroupedViewColumnsVisibilityMap)),
+    mSetting_GroupedViewColumnsCopyPasteMap(createGroupedViewColumnsVisibilityMapSettingsItem(sGroupedViewColumnsCopyPasteMapKey,
+        [this](const tGroupedViewColumnsVisibilityMap& data){groupedViewColumnsCopyPasteMapChanged(data);},
+        [this](){tryStoreSettingsConfig();},
+        sDefaultGroupedViewColumnsVisibilityMap)),
     mRootSettingItemPtrVec(),
     mUserSettingItemPtrVec(),
     mPatternsSettingItemPtrVec(),
@@ -302,6 +307,7 @@ CSettingsManager::CSettingsManager():
     mUserSettingItemPtrVec.push_back(&mSetting_FilterVariables);
     mUserSettingItemPtrVec.push_back(&mSetting_SelectedRegexFile);
     mUserSettingItemPtrVec.push_back(&mSetting_GroupedViewColumnsVisibilityMap);
+    mUserSettingItemPtrVec.push_back(&mSetting_GroupedViewColumnsCopyPasteMap);
 
     /////////////// PATTERNS SETTINGS ///////////////
     mPatternsSettingItemPtrVec.push_back(&mSetting_Aliases);
@@ -1309,6 +1315,11 @@ void CSettingsManager::setGroupedViewColumnsVisibilityMap(const tGroupedViewColu
     mSetting_GroupedViewColumnsVisibilityMap.setData(val);
 }
 
+void CSettingsManager::setGroupedViewColumnsCopyPasteMap(const tGroupedViewColumnsVisibilityMap& val)
+{
+    mSetting_GroupedViewColumnsCopyPasteMap.setData(val);
+}
+
 void CSettingsManager::setSelectedRegexFile(const QString& val)
 {
     mSetting_SelectedRegexFile.setData(val);
@@ -1438,6 +1449,11 @@ QString CSettingsManager::getSelectedRegexFile() const
  const tGroupedViewColumnsVisibilityMap& CSettingsManager::getGroupedViewColumnsVisibilityMap() const
  {
      return mSetting_GroupedViewColumnsVisibilityMap.getData();
+ }
+
+ const tGroupedViewColumnsVisibilityMap& CSettingsManager::getGroupedViewColumnsCopyPasteMap() const
+ {
+     return mSetting_GroupedViewColumnsCopyPasteMap.getData();
  }
 
 QString CSettingsManager::getRegexDirectory() const
@@ -1689,4 +1705,9 @@ void CSettingsManager::resetRegexFiltersColumnsVisibilityMap()
 void CSettingsManager::resetGroupedViewColumnsVisibilityMap()
 {
     setGroupedViewColumnsVisibilityMap(sDefaultGroupedViewColumnsVisibilityMap);
+}
+
+void CSettingsManager::resetGroupedViewColumnsCopyPasteMap()
+{
+    setGroupedViewColumnsCopyPasteMap(sDefaultGroupedViewColumnsVisibilityMap);
 }

--- a/dltmessageanalyzerplugin/src/settings/CSettingsManager.hpp
+++ b/dltmessageanalyzerplugin/src/settings/CSettingsManager.hpp
@@ -65,6 +65,7 @@ public:
     void resetPatternsColumnsCopyPasteMap();
     void resetRegexFiltersColumnsVisibilityMap();
     void resetGroupedViewColumnsVisibilityMap();
+    void resetGroupedViewColumnsCopyPasteMap();
     QString getRegexDirectory() const;
     QString getRegexDirectoryFull() const;
     QString getUserSettingsFilepath() const;
@@ -103,6 +104,7 @@ public:
     void setRegexFiltersColumnsVisibilityMap(const tRegexFiltersColumnsVisibilityMap& val);
     void setFilterVariables(bool val);
     void setGroupedViewColumnsVisibilityMap(const tGroupedViewColumnsVisibilityMap& val);
+    void setGroupedViewColumnsCopyPasteMap(const tGroupedViewColumnsVisibilityMap& val);
 
     /**
      * @brief setSelectedRegexFile - updates selected regex file
@@ -144,6 +146,7 @@ public:
     bool getFilterVariables() const;
     QString getSelectedRegexFile() const;
     const tGroupedViewColumnsVisibilityMap& getGroupedViewColumnsVisibilityMap() const;
+    const tGroupedViewColumnsVisibilityMap& getGroupedViewColumnsCopyPasteMap() const;
 
 ////////////////////////NOTIFICATIONS/////////////////////////////
 
@@ -179,6 +182,7 @@ signals:
     void filterVariablesChanged(bool filterVariables);
     void selectedRegexFileChanged( const QString& regexDirectory );
     void groupedViewColumnsVisibilityMapChanged(const tGroupedViewColumnsVisibilityMap& groupedViewColumnsVisibilityMap);
+    void groupedViewColumnsCopyPasteMapChanged(const tGroupedViewColumnsVisibilityMap& groupedViewColumnsCopyPasteMap);
 
 private: // methods
 
@@ -396,6 +400,7 @@ private: // fields
     TSettingItem<bool> mSetting_FilterVariables;
     TSettingItem<QString> mSetting_SelectedRegexFile; // name of the regex file to be used.
     TSettingItem<tGroupedViewColumnsVisibilityMap> mSetting_GroupedViewColumnsVisibilityMap;
+    TSettingItem<tGroupedViewColumnsVisibilityMap> mSetting_GroupedViewColumnsCopyPasteMap;
 
     typedef ISettingItem* tSettingItemPtr;
     typedef std::vector<tSettingItemPtr> tSettingItemsPtrVec;


### PR DESCRIPTION
#### [ISSUE #30][GROUPED_VIEW] Add the possibility to mark columns, which should be copied during the copy operation

1. [X] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [X] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [X] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Addition of the "Copy columns" settings to the grouped view

#### Verification criteria:

- Tested manually on Windows
- Build verified on github for Windows and Linux