### PR TITLE
[ISSUE #20][SEARCH_VIEW] Add the possibility to copy the file name of the specific message

### DIFF
--- a/dltmessageanalyzerplugin/src/dltWrappers/CDLTFileWrapper.hpp
+++ b/dltmessageanalyzerplugin/src/dltWrappers/CDLTFileWrapper.hpp
@@ -12,6 +12,7 @@
 #include "QSet"
 #include "QMap"
 #include "QObject"
+#include "QFile"
 
 #include "../common/Definitions.hpp"
 
@@ -302,7 +303,26 @@ private:
 
         private:
             bool mbSubFilesInitialized;
-            typedef std::map<QString, std::shared_ptr<QDltFile> > tSubFilesMap;
+
+            class CDLTFileItem
+            {
+                public:
+                    CDLTFileItem(const QString& path);
+                    bool updateIndex();
+                    int size();
+
+                private:
+                    // file path
+                    QString mPath;
+
+                    // DLT log file.
+                    QFile mInfile;
+
+                    // index
+                    QVector<qint64> mIndexAll;
+            };
+
+            typedef std::map<QString, std::shared_ptr<CDLTFileItem> > tSubFilesMap;
             tSubFilesMap mSubFilesMap;
             QDltFile* mpFile;
     };


### PR DESCRIPTION
## [ISSUE #20][SEARCH_VIEW] Add the possibility to copy the file name of the specific message

1. [X] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [X] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [X] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Fix bug with error messages, fired by dlt-viewer due to the shared access to the dlt file between the plugin and the viewer. That caused impossibility to delete tmp files.

----

#### Verification criteria:

- All checks on git-hub passed
- Manually tested on Windows