### PR TITLE
[ISSUE #76][SEARCH] Integrate regex name scripting with plantuml.jar

### DIFF
--- a/dltmessageanalyzerplugin/src/CDLTMessageAnalyzer.cpp
+++ b/dltmessageanalyzerplugin/src/CDLTMessageAnalyzer.cpp
@@ -1648,7 +1648,7 @@ void CDLTMessageAnalyzer::searchView_clicked_jumpTo_inMainTable(const QModelInde
 
         if(fileIdx >= 0)
         {
-            auto jumpIndex = mpMainTableView->model()->index( fileIdx, index.column() );
+            auto jumpIndex = mpMainTableView->model()->index( fileIdx, 0 );
             mpMainTableView->setFocus();
             mpMainTableView->scrollTo( jumpIndex, QAbstractItemView::ScrollHint::PositionAtCenter );
             mpMainTableView->setCurrentIndex(jumpIndex);

--- a/dltmessageanalyzerplugin/src/settings/CSettingsManager.cpp
+++ b/dltmessageanalyzerplugin/src/settings/CSettingsManager.cpp
@@ -686,13 +686,15 @@ TSettingItem<tSearchResultColumnsVisibilityMap> CSettingsManager::createSearchRe
 
     auto readFunc = [](const QJsonValueRef& JSONItem,
                        tSearchResultColumnsVisibilityMap& data,
-                       const tSearchResultColumnsVisibilityMap&)->bool
+                       const tSearchResultColumnsVisibilityMap& defaultValues)->bool
     {
         bool bResult = false;
 
         if(true == JSONItem.isArray())
         {
             data.clear();
+
+            auto defaultValuesCopy = defaultValues;
 
             auto searchResultColumnsVisibilityArray = JSONItem.toArray();
             for( const auto searchResultColumnsVisibilityObj : searchResultColumnsVisibilityArray )
@@ -719,7 +721,22 @@ TSettingItem<tSearchResultColumnsVisibilityMap> CSettingsManager::createSearchRe
 
                                     bool bIsVisible = foundVisibilityValue->toBool();
                                     data.insert(static_cast<eSearchResultColumn>(columnIdx), bIsVisible);
+
+                                    auto foundDefaultValue = defaultValuesCopy.find(static_cast<eSearchResultColumn>(columnIdx));
+
+                                    if(foundDefaultValue != defaultValuesCopy.end())
+                                    {
+                                        defaultValuesCopy.erase(foundDefaultValue);
+                                    }
                                 }
+                            }
+                        }
+
+                        if(false == defaultValuesCopy.empty()) // if there are some non-existing elements in the file
+                        {
+                            for(auto it = defaultValuesCopy.begin(); it != defaultValuesCopy.end(); ++it) // let's fill them in with default values
+                            {
+                                data.insert(static_cast<eSearchResultColumn>(it.key()), it.value());
                             }
                         }
                     }


### PR DESCRIPTION
#### [ISSUE #76][SEARCH] Integrate regex name scripting with plantuml.jar
1. [X] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [X] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [X] Is your change backward-compatible with the previous version of the plugin?

## Change description:
- Fix of bug with non-jumping main window of the dlt-viewer, when double-clicking on the Payload column of the Search View
- Fix of bug with non visible Payload column of the Search View, when updating from older version of the plugin with already existing user settings

## Verification criteria:

- Build and related functionality were checked both on Windows & Linux
- All sanity checks on Git hub were passed