### PR TITLE
[ISSUE #88][FILTERS_VIEW] Filter view breaks the regex after changing the variable's value

### DIFF
--- a/dltmessageanalyzerplugin/src/filtersView/CFiltersModel.cpp
+++ b/dltmessageanalyzerplugin/src/filtersView/CFiltersModel.cpp
@@ -359,7 +359,7 @@ QPair<bool,QString> CFiltersModel::packRegex()
             return true;
         };
 
-        mpRootItem->visit(preVisitFunction, postVisitFunction, false);
+        mpRootItem->visit(preVisitFunction, postVisitFunction, false, true, false);
 
         SEND_MSG(regexStr);
 


### PR DESCRIPTION
## [ISSUE #88][FILTERS_VIEW] Filter view breaks the regex after changing the variable's value

1. [X] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [X] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [X] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Change of implementation of the filters model to iterate over non-sorted tree while packing the regex string

#### Verification criteria:

- Tested manually on Windows 10
- All sanity checks on Git hub were passed successfully