### PR TITLE
[ISSUE #92][SETTINGS_MANAGER] Add possibility to check arithmetic types settings against set of allowed range of values

### DIFF
--- a/DLT-Message-Analyzer.pro
+++ b/DLT-Message-Analyzer.pro
@@ -11,7 +11,7 @@ UI_DIR      = build/ui
 # DEFINES += PLUGIN_API_COMPATIBILITY_MODE_1_0_0
 
 # target name
-TARGET = $$qtLibraryTarget(dltmessageanalyzerplugin)
+# TARGET = $$qtLibraryTarget(dltmessageanalyzerplugin)
 
 INCLUDEPATH+=dltmessageanalyzerplugin/src
 
@@ -45,6 +45,8 @@ HEADERS += \
     dltmessageanalyzerplugin/src/common/CBGColorAnimation.hpp \
     dltmessageanalyzerplugin/src/common/CRegexDirectoryMonitor.hpp \
     dltmessageanalyzerplugin/src/common/OSHelper.hpp \
+    dltmessageanalyzerplugin/src/common/TOptional.hpp \
+    dltmessageanalyzerplugin/src/common/cpp_extensions.hpp \
     \
     dltmessageanalyzerplugin/src/dltWrappers/CDLTFileWrapper.hpp \
     dltmessageanalyzerplugin/src/dltWrappers/CDLTMsgWrapper.hpp \

--- a/dltmessageanalyzerplugin/src/CDLTMessageAnalyzer.cpp
+++ b/dltmessageanalyzerplugin/src/CDLTMessageAnalyzer.cpp
@@ -104,8 +104,8 @@ CDLTMessageAnalyzer::CDLTMessageAnalyzer(const std::weak_ptr<IDLTMessageAnalyzer
     mpConsoleInputProcessor(std::make_shared<CConsoleInputProcessor>(pConsoleViewInput))
 {
     //////////////METATYPES_REGISTRATION/////////////////////
-    qRegisterMetaType<tRangePtrWrapper>("tRangePtrWrapper");
-    qRegisterMetaType<tRange>("tRange");
+    qRegisterMetaType<tIntRangePtrWrapper>("tIntRangePtrWrapper");
+    qRegisterMetaType<tIntRange>("tIntRange");
     qRegisterMetaType<const tFoundMatch*>("const tFoundMatch*");
 
     qRegisterMetaType<eRegexFiltersRowType>("eRegexFiltersRowType");
@@ -375,7 +375,7 @@ CDLTMessageAnalyzer::CDLTMessageAnalyzer(const std::weak_ptr<IDLTMessageAnalyzer
             static_cast<void>(analyze());
         });
 
-        connect( mpSearchResultTableView, &CSearchResultView::searchRangeChanged, [this](const tRangeProperty& searchRange, bool bReset)
+        connect( mpSearchResultTableView, &CSearchResultView::searchRangeChanged, [this](const tIntRangeProperty& searchRange, bool bReset)
         {
             if(false == bReset)
             {
@@ -683,7 +683,7 @@ void CDLTMessageAnalyzer::resetSearchRange()
         }
     }
 
-    mSearchRange = tRangeProperty();
+    mSearchRange = tIntRangeProperty();
 }
 
 void CDLTMessageAnalyzer::setFile(const tDLTFileWrapperPtr& pFile)
@@ -850,7 +850,7 @@ bool CDLTMessageAnalyzer::analyze()
             return false;
         }
 
-        tRange requestedMessages;
+        tIntRange requestedMessages;
 
         if(true == mSearchRange.isSet)
         {

--- a/dltmessageanalyzerplugin/src/CDLTMessageAnalyzer.hpp
+++ b/dltmessageanalyzerplugin/src/CDLTMessageAnalyzer.hpp
@@ -299,7 +299,7 @@ signals:
         CUMLView* mpUMLView;
 
         // internal states
-        tRangeProperty mSearchRange;
+        tIntRangeProperty mSearchRange;
         tRequestId mRequestId;
         int mNumberOfDots;
         bool mbIsConnected;

--- a/dltmessageanalyzerplugin/src/analyzer/CDLTRegexAnalyzerWorker.cpp
+++ b/dltmessageanalyzerplugin/src/analyzer/CDLTRegexAnalyzerWorker.cpp
@@ -99,7 +99,7 @@ void CDLTRegexAnalyzerWorker::analyzePortion( const tRequestId& requestId,
                         if(0 != matchItem.size())
                         {
                             foundMatches.push_back( tFoundMatch( std::make_shared<QString>(matchItem),
-                                                                 tRange( match.capturedStart(i), match.capturedEnd(i) - 1 ),
+                                                                 tIntRange( match.capturedStart(i), match.capturedEnd(i) - 1 ),
                                                                  i,
                                                                  processingString.first.msgSize,
                                                                  processingString.first.timeStamp,

--- a/dltmessageanalyzerplugin/src/analyzer/CMTAnalyzer.cpp
+++ b/dltmessageanalyzerplugin/src/analyzer/CMTAnalyzer.cpp
@@ -17,6 +17,7 @@
 #include "IDLTMessageAnalyzerControllerConsumer.hpp"
 #include "../dltWrappers/CDLTMsgWrapper.hpp"
 #include "../log/CConsoleCtrl.hpp"
+#include "../common/cpp_extensions.hpp"
 
 //#define DEBUG_MESSAGES
 
@@ -180,9 +181,9 @@ bool CMTAnalyzer::regexAnalysisIteration(tRequestMap::iterator& inputIt, const t
                     QString ctId = pMsg->getCtid();
 
                     auto appIdSize = appId.size();
-                    tRange appRange( 0, appIdSize - 1 );
+                    tIntRange appRange( 0, appIdSize - 1 );
                     auto ctIdSize = ctId.size();
-                    tRange ctRange( appRange.to + 2, appRange.to + 2 + ctIdSize - 1 );
+                    tIntRange ctRange( appRange.to + 2, appRange.to + 2 + ctIdSize - 1 );
 
                     QString payloadStr = pMsg->getPayload();
                     auto payloadSize = payloadStr.size();
@@ -191,7 +192,7 @@ bool CMTAnalyzer::regexAnalysisIteration(tRequestMap::iterator& inputIt, const t
                     pStr->reserve(appId.size() + ctId.size() + payloadStr.size() + 2);
                     pStr->append( appId ).append(" ").append( ctId ).append(" ").append(payloadStr);
 
-                    tRange payloadRange( ctRange.to + 2, ctRange.to + 2 + payloadSize - 1 );
+                    tIntRange payloadRange( ctRange.to + 2, ctRange.to + 2 + payloadSize - 1 );
 
                     tFieldRanges fieldRanges;
 

--- a/dltmessageanalyzerplugin/src/common/Definitions.cpp
+++ b/dltmessageanalyzerplugin/src/common/Definitions.cpp
@@ -419,50 +419,8 @@ bool tHighlightingRange::operator< ( const tHighlightingRange& rVal ) const
    return bResult;
 }
 
-/// tRange
-tRange::tRange( const tRangeItem& from_, const tRangeItem& to_ ):
-from(from_), to(to_)
-{}
-
-tRange::tRange():
-from(0), to(0)
-{}
-
-bool tRange::operator< ( const tRange& rVal ) const
-{
-    bool bResult = false;
-
-    if( from < rVal.from )
-    {
-        bResult = true;
-    }
-    else if( from > rVal.from )
-    {
-        bResult = false;
-    }
-    else // if from == rVal.from
-    {
-        if( to < rVal.to )
-        {
-            bResult = true;
-        }
-        else
-        {
-            bResult = false;
-        }
-    }
-
-    return bResult;
-}
-
-bool tRange::operator== ( const tRange& rVal ) const
-{
-    return ( from == rVal.from && to == rVal.to );
-}
-
-
-/////////////////////////////tRangePtrWrapper/////////////////////////////
-bool tRangePtrWrapper::operator< ( const tRangePtrWrapper& rVal ) const
+/////////////////////////////tIntRangePtrWrapper/////////////////////////////
+bool tIntRangePtrWrapper::operator< ( const tIntRangePtrWrapper& rVal ) const
 {
     bool bResult = false;
 
@@ -498,7 +456,7 @@ bool tRangePtrWrapper::operator< ( const tRangePtrWrapper& rVal ) const
     return bResult;
 }
 
-bool tRangePtrWrapper::operator== ( const tRangePtrWrapper& rVal ) const
+bool tIntRangePtrWrapper::operator== ( const tIntRangePtrWrapper& rVal ) const
 {
     if(pRange == nullptr && rVal.pRange != nullptr)
         return false;
@@ -513,8 +471,8 @@ bool tRangePtrWrapper::operator== ( const tRangePtrWrapper& rVal ) const
 
 struct tAnalysisRange
 {
-    tAnalysisRange(const tRange& inputRange,
-                   const tRange& shrinkToRange):
+    tAnalysisRange(const tIntRange& inputRange,
+                   const tIntRange& shrinkToRange):
         bFromShrinked(false),
         bToShrinked(false)
     {
@@ -539,9 +497,9 @@ struct tAnalysisRange
         }
     }
 
-    tRangeItem from;
+    tIntRange::tRangeItem from;
     bool bFromShrinked;
-    tRangeItem to;
+    tIntRange::tRangeItem to;
     bool bToShrinked;
 };
 
@@ -609,7 +567,7 @@ tTreeItemSharedPtr getMatchesTree( const tFoundMatches& foundMatches )
 
             assert(false == data.empty());
 
-            tRangePtrWrapper rangePtrWrapper;
+            tIntRangePtrWrapper rangePtrWrapper;
             rangePtrWrapper.pRange = &match.range;
             tDataItem rangeVariant( rangePtrWrapper );
             auto* pAddedChild = pCurrentItem->appendChild(rangeVariant, data);
@@ -671,7 +629,7 @@ tTreeItemSharedPtr getMatchesTree( const tFoundMatches& foundMatches )
 }
 
 tCalcRangesCoverageMulticolorResult calcRangesCoverageMulticolor( const tTreeItemSharedPtr& pMatchesTree,
-                               const tRange& inputRange,
+                               const tIntRange& inputRange,
                                const tRegexScriptingMetadata& regexScriptingMetadata,
                                const QVector<QColor>& gradientColors,
                                const tGroupIdToColorMap& groupIdToColorMap )
@@ -763,7 +721,7 @@ tCalcRangesCoverageMulticolorResult calcRangesCoverageMulticolor( const tTreeIte
                 if( firstChildAnalysisRange.from > analysisRange.from ) // if there is room for additional range
                 {
                     // let's add it
-                    tAnalysisRange rangeToBeAdded( tRange( analysisRange.from, firstChildAnalysisRange.from - 1 ), inputRange);
+                    tAnalysisRange rangeToBeAdded( tIntRange( analysisRange.from, firstChildAnalysisRange.from - 1 ), inputRange);
                     resultList.push_back( tHighlightingRange( rangeToBeAdded.from,
                                                               rangeToBeAdded.to,
                                                               selectedColor.second,
@@ -784,7 +742,7 @@ tCalcRangesCoverageMulticolorResult calcRangesCoverageMulticolor( const tTreeIte
 
                     if((secondChildAnalysisRange.from - firstChildAnalysisRange.to) > 1)
                     {
-                        tAnalysisRange rangeToBeAdded( tRange( firstChildAnalysisRange.to+1, secondChildAnalysisRange.from-1 ), inputRange);
+                        tAnalysisRange rangeToBeAdded( tIntRange( firstChildAnalysisRange.to+1, secondChildAnalysisRange.from-1 ), inputRange);
                         resultList.push_back( tHighlightingRange( rangeToBeAdded.from,
                                                                   rangeToBeAdded.to,
                                                                   selectedColor.second,
@@ -802,7 +760,7 @@ tCalcRangesCoverageMulticolorResult calcRangesCoverageMulticolor( const tTreeIte
                 if( analysisRange.to > lastChildAnalysisRange.to ) // if there is room for additional range
                 {
                     // let's add it
-                    tAnalysisRange rangeToBeAdded( tRange( lastChildAnalysisRange.to + 1, analysisRange.to ), inputRange);
+                    tAnalysisRange rangeToBeAdded( tIntRange( lastChildAnalysisRange.to + 1, analysisRange.to ), inputRange);
                     resultList.push_back( tHighlightingRange( rangeToBeAdded.from,
                                                               rangeToBeAdded.to,
                                                               selectedColor.second,
@@ -1069,7 +1027,7 @@ tTreeItemSharedPtr tItemMetadata::updateUMLInfo(const tFoundMatches& foundMatche
                                 if(true == insideRange) // if group is even partially inside the range
                                 {
                                     tStringCoverageItem stringCoverageItem;
-                                    stringCoverageItem.range = tRange( std::max(fieldRange.from, match.range.from) - fieldRange.from,
+                                    stringCoverageItem.range = tIntRange( std::max(fieldRange.from, match.range.from) - fieldRange.from,
                                                                        std::min( fieldRange.to, match.range.to ) - fieldRange.from );
                                     stringCoverageItem.bAddSeparator = match.range.to > fieldRange.to;
                                     UMLDataItem.stringCoverageMap[it.key()] = stringCoverageItem;
@@ -1109,7 +1067,7 @@ msgId(0)
 {}
 
 tFoundMatch::tFoundMatch( const tQStringPtr& pMatchStr_,
-                          const tRange& range_,
+                          const tIntRange& range_,
                           const int& idx_,
                           const unsigned int& msgSizeBytes_,
                           const unsigned int& timeStamp_,
@@ -2073,9 +2031,9 @@ QVariant toQVariant(const tDataItem& item)
     {
         result.setValue(item.get<tGroupedViewMetadata>());
     }
-    else if(item.index() == tDataItem::index_of<tRangePtrWrapper>())
+    else if(item.index() == tDataItem::index_of<tIntRangePtrWrapper>())
     {
-        result.setValue(item.get<tRangePtrWrapper>());
+        result.setValue(item.get<tIntRangePtrWrapper>());
     }
     else if(item.index() == tDataItem::index_of<tFoundMatch*>())
     {
@@ -2085,9 +2043,9 @@ QVariant toQVariant(const tDataItem& item)
     {
         result.setValue(item.get<tColorWrapper>());
     }
-    else if(item.index() == tDataItem::index_of<tRange>())
+    else if(item.index() == tDataItem::index_of<tIntRange>())
     {
-        result.setValue(item.get<tRange>());
+        result.setValue(item.get<tIntRange>());
     }
     else if(item.index() == tDataItem::index_of<eRegexFiltersRowType>())
     {
@@ -2126,7 +2084,7 @@ tDataItem toRegexDataItem(const QVariant& variant, const eRegexFiltersColumn& co
             break;
         case eRegexFiltersColumn::Range:
         {
-            result = variant.value<tRange>();
+            result = variant.value<tIntRange>();
         }
             break;
         case eRegexFiltersColumn::RowType:

--- a/dltmessageanalyzerplugin/src/common/OSHelper.cpp
+++ b/dltmessageanalyzerplugin/src/common/OSHelper.cpp
@@ -44,3 +44,17 @@ bool getRAMSize(uint32_t& val)
 
     return bResult;
 }
+
+uint32_t getRAMSizeUnchecked()
+{
+    uint32_t result = 0;
+
+    bool bOperationResult = getRAMSize(result);
+
+    if(false == bOperationResult)
+    {
+        result = 0;
+    }
+
+    return result;
+}

--- a/dltmessageanalyzerplugin/src/common/OSHelper.hpp
+++ b/dltmessageanalyzerplugin/src/common/OSHelper.hpp
@@ -6,10 +6,17 @@
 // helper, which is used to wrap operating system dependent functionality
 
 /**
- * @brief getRAMSize - returns back abount of RAM on target machine
+ * @brief getRAMSize - returns back abount of RAM ( in Mb ) on the target machine
  * @return - amount of RAM in Megaytes
  * Note! This function is supported for Windows and Linux.
  */
 bool getRAMSize(uint32_t& val);
+
+/**
+ * @brief getRAMSizeUnchecked - will return RAM size ( in MB ) on the target machine.
+ * Does not provide bool result of operation.
+ * @return - RAM size in case of success or 0 Otherwise.
+ */
+uint32_t getRAMSizeUnchecked();
 
 #endif // OSHELPER_HPP

--- a/dltmessageanalyzerplugin/src/common/TOptional.hpp
+++ b/dltmessageanalyzerplugin/src/common/TOptional.hpp
@@ -1,0 +1,53 @@
+#ifndef TOPTIONAL_HPP
+#define TOPTIONAL_HPP
+
+/**
+ * @brief - very very very poor replacement of std::optional & boost::optional
+ * Created, as we need to support C++11 as of now.
+ * Also Qt has no replacement, and we do not want to mix Qt with boost.
+ * Once we will switch to C++17 this one will be definitely replaced to std::optional
+ */
+
+#include "assert.h"
+
+template<typename T>
+class TOptional
+{
+
+public:
+    TOptional();
+
+    explicit TOptional(const T& val):
+    mData(val),
+    mbIsSet(true)
+    {}
+
+    void setValue(const T& val)
+    {
+        mData = val;
+        mbIsSet = true;
+    }
+
+    const T& getValue() const
+    {
+        assert(mbIsSet);
+        return mData;
+    }
+
+    T& getWriteableValue()
+    {
+        assert(mbIsSet);
+        return mData;
+    }
+
+    bool isSet() const
+    {
+        return mbIsSet;
+    }
+
+private:
+    T mData;
+    bool mbIsSet;
+};
+
+#endif // TOPTIONAL_HPP

--- a/dltmessageanalyzerplugin/src/common/cpp_extensions.hpp
+++ b/dltmessageanalyzerplugin/src/common/cpp_extensions.hpp
@@ -1,0 +1,19 @@
+#ifndef CPP_EXTENSIONS_HPP
+#define CPP_EXTENSIONS_HPP
+
+#include <type_traits>
+#include <memory>
+
+namespace cpp_14
+{
+    template<bool C, class T = void>
+    using enable_if_t = typename std::enable_if<C, T>::type;
+
+    template<typename T, typename... Args>
+    std::unique_ptr<T> make_unique(Args&&... args)
+    {
+        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    }
+}
+
+#endif // CPP_EXTENSIONS_HPP

--- a/dltmessageanalyzerplugin/src/dltWrappers/CDLTFileWrapper.cpp
+++ b/dltmessageanalyzerplugin/src/dltWrappers/CDLTFileWrapper.cpp
@@ -379,7 +379,7 @@ bool CDLTFileWrapper::cacheMsgByIndexes( const QSet<tMsgId> msgIdSet )
     return bResult;
 }
 
-bool CDLTFileWrapper::cacheMsgByRange( const tRange& msgRange )
+bool CDLTFileWrapper::cacheMsgByRange( const tIntRange& msgRange )
 {
     bool bResult = true;
 
@@ -484,9 +484,9 @@ int CDLTFileWrapper::binarySearch(bool isFrom, const int& fromIdx, const int& to
     return (true == isFrom) ? std::min(fromIdx, toIdx) : std::max(fromIdx, toIdx);
 }
 
-tRangeProperty CDLTFileWrapper::normalizeSearchRange( const tRangeProperty& inputRange)
+tIntRangeProperty CDLTFileWrapper::normalizeSearchRange( const tIntRangeProperty& inputRange)
 {
-    tRangeProperty result;
+    tIntRangeProperty result;
 
     if(false == inputRange.isSet)
     {
@@ -532,9 +532,9 @@ QString CDLTFileWrapper::getCacheStatusAsString() const
 }
 
 
-tRangeList CDLTFileWrapper::getSubFilesSizeRanges() const
+tIntRangeList CDLTFileWrapper::getSubFilesSizeRanges() const
 {
-    tRangeList result;
+    tIntRangeList result;
 
     if(nullptr != mpSubFilesHandler && true == mpSubFilesHandler->getSubFilesHandlingStatus())
     {
@@ -572,7 +572,7 @@ void CDLTFileWrapper::copyFileNameToClipboard( const int& msgId ) const
     }
 }
 
-void CDLTFileWrapper::copyFileNamesToClipboard( const tRange& msgsRange ) const
+void CDLTFileWrapper::copyFileNamesToClipboard( const tIntRange& msgsRange ) const
 {
     if(nullptr != mpSubFilesHandler)
     {
@@ -655,9 +655,9 @@ void CDLTFileWrapper::CSubFilesHandler::setSubFilesHandlingStatus(const bool& va
     }
 }
 
-tRangeList CDLTFileWrapper::CSubFilesHandler::getSubFilesSizeRanges() const
+tIntRangeList CDLTFileWrapper::CSubFilesHandler::getSubFilesSizeRanges() const
 {
-    tRangeList result;
+    tIntRangeList result;
 
     if(true == mbSubFilesInitialized)
     {
@@ -667,7 +667,7 @@ tRangeList CDLTFileWrapper::CSubFilesHandler::getSubFilesSizeRanges() const
 
         for(const auto& item : mSubFilesMap)
         {
-            tRange analyzedRange;
+            tIntRange analyzedRange;
             analyzedRange.from = processedIndexes + 1;
             analyzedRange.to += processedIndexes + 1 + item.second->size() - 1;
             result.push_back(analyzedRange);
@@ -708,7 +708,7 @@ void CDLTFileWrapper::CSubFilesHandler::copyFileNameToClipboard( const int& msgI
     }
 }
 
-void CDLTFileWrapper::CSubFilesHandler::copyFileNamesToClipboard( const tRange& msgsRange ) const
+void CDLTFileWrapper::CSubFilesHandler::copyFileNamesToClipboard( const tIntRange& msgsRange ) const
 {
     if( nullptr != mpFile && true == mbSubFilesInitialized )
     {

--- a/dltmessageanalyzerplugin/src/dltWrappers/CDLTFileWrapper.hpp
+++ b/dltmessageanalyzerplugin/src/dltWrappers/CDLTFileWrapper.hpp
@@ -155,7 +155,7 @@ public:
      * @return - true, if caching was successfully done.
      * False otherwise - if cache is disables or overflowed.
      */
-    bool cacheMsgByRange( const tRange& msgRange );
+    bool cacheMsgByRange( const tIntRange& msgRange );
 
     /**
      * @brief resetCache - resets the cache
@@ -170,7 +170,7 @@ public:
      * @param inputRange - range in absolute indexes
      * @return - range in relative indexes
      */
-    tRangeProperty normalizeSearchRange( const tRangeProperty& inputRange);
+    tIntRangeProperty normalizeSearchRange( const tIntRangeProperty& inputRange);
 
     /**
      * @brief formCacheStatusString - forms cache status string to be shown in UI
@@ -208,7 +208,7 @@ public:
      * @return  - instance of the vector, which lists ranges of messages in each physical file
      * Note! This functionality works ONLY if subFilesHandlingStatus was switched to "ON".
      */
-    tRangeList getSubFilesSizeRanges() const;
+    tIntRangeList getSubFilesSizeRanges() const;
 
     /**
      * @brief copyFileNameToClipboard - copies file name associated with provided msgId to clipboard
@@ -222,7 +222,7 @@ public:
      * @param msgsRange - range of messages to be checked
      * Note! This functionality works ONLY if subFilesHandlingStatus was switched to "ON".
      */
-    void copyFileNamesToClipboard( const tRange& msgsRange ) const;
+    void copyFileNamesToClipboard( const tIntRange& msgsRange ) const;
 
 signals:
     /**
@@ -293,9 +293,9 @@ private:
             void setFile( QDltFile* pFile );
             void setSubFilesHandlingStatus(const bool& value);
             bool getSubFilesHandlingStatus() const;
-            tRangeList getSubFilesSizeRanges() const;
+            tIntRangeList getSubFilesSizeRanges() const;
             void copyFileNameToClipboard( const int& msgId ) const;
-            void copyFileNamesToClipboard( const tRange& msgsRange ) const;
+            void copyFileNamesToClipboard( const tIntRange& msgsRange ) const;
 
         private:
             void updateSubFiles();

--- a/dltmessageanalyzerplugin/src/filtersView/CFiltersModel.cpp
+++ b/dltmessageanalyzerplugin/src/filtersView/CFiltersModel.cpp
@@ -454,7 +454,7 @@ struct tParsingDataItem
     QString name;
     QString value;
     tColorWrapper colorWrapper;
-    tRange range;
+    tIntRange range;
     eRegexFiltersRowType rowType = eRegexFiltersRowType::Text;
     bool isFiltered = false;
     QString groupName;

--- a/dltmessageanalyzerplugin/src/filtersView/CFiltersView.cpp
+++ b/dltmessageanalyzerplugin/src/filtersView/CFiltersView.cpp
@@ -476,7 +476,7 @@ void CFiltersView::currentChanged(const QModelIndex &current, const QModelIndex 
         if(nullptr != pTreeItem &&
            nullptr != mpRegexInputField)
         {
-            auto range = pTreeItem->data(static_cast<int>(eRegexFiltersColumn::Range)).get<tRange>();
+            auto range = pTreeItem->data(static_cast<int>(eRegexFiltersColumn::Range)).get<tIntRange>();
             mpRegexInputField->setSelection(range.from, range.to - range.from);
         }
     }

--- a/dltmessageanalyzerplugin/src/searchView/CSearchResultModel.cpp
+++ b/dltmessageanalyzerplugin/src/searchView/CSearchResultModel.cpp
@@ -266,9 +266,9 @@ Qt::ItemFlags CSearchResultModel::flags(const QModelIndex &index) const
     return result;
 }
 
-std::pair<bool, tRange> CSearchResultModel::addNextMessageIdxVec(const tFoundMatchesPack &foundMatchesPack)
+std::pair<bool, tIntRange> CSearchResultModel::addNextMessageIdxVec(const tFoundMatchesPack &foundMatchesPack)
 {
-    std::pair<bool, tRange> result;
+    std::pair<bool, tIntRange> result;
 
     if(false == foundMatchesPack.matchedItemVec.empty())
     {
@@ -340,8 +340,8 @@ std::pair<int /*rowNumber*/, QString /*diagramContent*/> CSearchResultModel::get
 
             // Result string - <UCL> <URT|URS|UE> <US> : [timestamp] <USID><UM>(<UA>)
 
-            tRange insertMethodFormattingRange;
-            tRange insertMethodFormattingOffset;
+            tIntRange insertMethodFormattingRange;
+            tIntRange insertMethodFormattingOffset;
 
             auto getUMLItemRepresentation = [this, &itemMetadata, &pMsg](const eUML_ID& UML_ID)->std::pair<bool, QString>
             {

--- a/dltmessageanalyzerplugin/src/searchView/CSearchResultModel.hpp
+++ b/dltmessageanalyzerplugin/src/searchView/CSearchResultModel.hpp
@@ -31,7 +31,7 @@ public:
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
-    std::pair<bool, tRange> addNextMessageIdxVec(const tFoundMatchesPack& foundMatchesPack);
+    std::pair<bool, tIntRange> addNextMessageIdxVec(const tFoundMatchesPack& foundMatchesPack);
     std::pair<int /*rowNumber*/, QString /*diagramContent*/> getUMLDiagramContent() const;
 
     const tFoundMatchesPackItem& getFoundMatchesItemPack( const QModelIndex& modelIndex ) const;

--- a/dltmessageanalyzerplugin/src/searchView/CSearchResultView.cpp
+++ b/dltmessageanalyzerplugin/src/searchView/CSearchResultView.cpp
@@ -152,7 +152,7 @@ CSearchResultView::CSearchResultView(QWidget *parent):
                     tMsgId from = minSelectedRow->sibling(minSelectedRow->row(), static_cast<int>(eSearchResultColumn::Index)).data().value<tMsgId>();
                     tMsgId to = maxSelectedRow->sibling(maxSelectedRow->row(), static_cast<int>(eSearchResultColumn::Index)).data().value<tMsgId>();
 
-                    tRangeProperty prop;
+                    tIntRangeProperty prop;
                     prop.isSet = true;
                     prop.from = from;
                     prop.to = ( to >= mpFile->sizeNonFiltered() - 1 ) ? mpFile->sizeNonFiltered() - 1 : to;
@@ -179,7 +179,7 @@ CSearchResultView::CSearchResultView(QWidget *parent):
                         QAction* pAction = new QAction(msg, this);
                         connect(pAction, &QAction::triggered, [this, targetMsgId]()
                         {
-                            tRangeProperty prop;
+                            tIntRangeProperty prop;
                             prop.isSet = true;
                             prop.from = targetMsgId;
 
@@ -213,7 +213,7 @@ CSearchResultView::CSearchResultView(QWidget *parent):
                         QAction* pAction = new QAction(msg, this);
                         connect(pAction, &QAction::triggered, [this, targetMsgId]()
                         {
-                            tRangeProperty prop;
+                            tIntRangeProperty prop;
                             prop.isSet = true;
                             prop.from = mSearchRange.from;
                             prop.to = ( targetMsgId >= mpFile->sizeNonFiltered() - 1 ) ? mpFile->sizeNonFiltered() - 1 : targetMsgId;
@@ -236,7 +236,7 @@ CSearchResultView::CSearchResultView(QWidget *parent):
                         QAction* pAction = new QAction(msg, this);
                         connect(pAction, &QAction::triggered, [this]()
                         {
-                            mSearchRange = tRangeProperty();
+                            mSearchRange = tIntRangeProperty();
                             searchRangeChanged( mSearchRange, true );
                         });
                         contextMenu.addAction(pAction);
@@ -719,7 +719,7 @@ void CSearchResultView::getUserSearchRange()
         int to = fields[1]->text().toInt( &isToADigit );
 
         // validation done in acceptHandler, so here no need to duplicate it
-        tRangeProperty prop;
+        tIntRangeProperty prop;
         prop.isSet = true;
         prop.from = from;
         prop.to = ( to >= mpFile->sizeNonFiltered() - 1 ) ? mpFile->sizeNonFiltered() - 1 : to;
@@ -731,7 +731,7 @@ void CSearchResultView::getUserSearchRange()
 
 void CSearchResultView::setFile( const tDLTFileWrapperPtr& pFile )
 {
-    mSearchRange = tRangeProperty();
+    mSearchRange = tIntRangeProperty();
     searchRangeChanged( mSearchRange, true );
 
     mpFile = pFile;
@@ -983,7 +983,7 @@ void CSearchResultView::copySelectionToClipboard( bool copyAsHTML, bool copyOnly
             eSearchResultColumn field = static_cast<eSearchResultColumn>(columnId);
             QString columnStr = column.data().value<QString>();
 
-            auto attachText = [&clipboardItems, &finalRichStringSize, &finalStringSize, &columnStr, &i, &copyPasteColumnsSize, &field](const tRange& range, const QColor& color, bool isHighlighted)
+            auto attachText = [&clipboardItems, &finalRichStringSize, &finalStringSize, &columnStr, &i, &copyPasteColumnsSize, &field](const tIntRange& range, const QColor& color, bool isHighlighted)
             {
                 bool isHighlightedExtended = ( isHighlighted ||
                                                ( eSearchResultColumn::Timestamp == field
@@ -1055,10 +1055,10 @@ void CSearchResultView::copySelectionToClipboard( bool copyAsHTML, bool copyOnly
                             {
                                 if(0 != range.from)
                                 {
-                                    attachText( tRange(0, range.from - 1 ), nonHighlightedColor, false );
+                                    attachText( tIntRange(0, range.from - 1 ), nonHighlightedColor, false );
                                 }
 
-                                attachText( tRange( range.from, range.to ), getHighlightedColor(*it), true );
+                                attachText( tIntRange( range.from, range.to ), getHighlightedColor(*it), true );
                             }
                             else if(0 < counter)
                             {
@@ -1068,17 +1068,17 @@ void CSearchResultView::copySelectionToClipboard( bool copyAsHTML, bool copyOnly
 
                                 if(prevRange.to < range.from)
                                 {
-                                    attachText( tRange(prevRange.to + 1, range.from - 1), nonHighlightedColor, false );
+                                    attachText( tIntRange(prevRange.to + 1, range.from - 1), nonHighlightedColor, false );
                                 }
 
-                                attachText( tRange( range.from, range.to ), getHighlightedColor(*it), true );
+                                attachText( tIntRange( range.from, range.to ), getHighlightedColor(*it), true );
                             }
 
                             if(counter == static_cast<int>(foundHighlightingItem->size() - 1)) // last element
                             {
                                 if( range.to < columnStr.size() - 1 )
                                 {
-                                    attachText( tRange(range.to + 1, columnStr.size() - 1), nonHighlightedColor, false );
+                                    attachText( tIntRange(range.to + 1, columnStr.size() - 1), nonHighlightedColor, false );
                                 }
                             }
 
@@ -1087,17 +1087,17 @@ void CSearchResultView::copySelectionToClipboard( bool copyAsHTML, bool copyOnly
                     }
                     else
                     {
-                        attachText( tRange(0, columnStr.size() - 1), nonHighlightedColor, false );
+                        attachText( tIntRange(0, columnStr.size() - 1), nonHighlightedColor, false );
                     }
                 }
                 else
                 {
-                    attachText( tRange(0, columnStr.size() - 1), nonHighlightedColor, false );
+                    attachText( tIntRange(0, columnStr.size() - 1), nonHighlightedColor, false );
                 }
             }
             else
             {
-                attachText( tRange(0, columnStr.size() - 1), nonHighlightedColor, false );
+                attachText( tIntRange(0, columnStr.size() - 1), nonHighlightedColor, false );
             }
         }
 
@@ -1239,13 +1239,13 @@ void CSearchResultView::copyMessageFiles()
                 tMsgId from = minSelectedRow->sibling(minSelectedRow->row(), static_cast<int>(eSearchResultColumn::Index)).data().value<tMsgId>();
                 tMsgId to = maxSelectedRow->sibling(maxSelectedRow->row(), static_cast<int>(eSearchResultColumn::Index)).data().value<tMsgId>();
 
-                tRangeProperty prop;
+                tIntRangeProperty prop;
                 prop.isSet = true;
                 prop.from = from;
                 prop.to = ( to >= mpFile->sizeNonFiltered() - 1 ) ? mpFile->sizeNonFiltered() - 1 : to;
                 prop = mpFile->normalizeSearchRange( prop );
 
-                mpFile->copyFileNamesToClipboard(tRange(prop.from, prop.to));
+                mpFile->copyFileNamesToClipboard(tIntRange(prop.from, prop.to));
             }
             else if(selectedRowsSize == 1)
             {

--- a/dltmessageanalyzerplugin/src/searchView/CSearchResultView.hpp
+++ b/dltmessageanalyzerplugin/src/searchView/CSearchResultView.hpp
@@ -26,7 +26,7 @@ public:
     void copySelectionToClipboard( bool copyAsHTML, bool copyOnlyPayload ) const;
 
 signals:
-    void searchRangeChanged( const tRangeProperty& searchRange, bool bReset );
+    void searchRangeChanged( const tIntRangeProperty& searchRange, bool bReset );
     void clearSearchResultsRequested();
     void restartSearch();
 
@@ -53,7 +53,7 @@ private:
     eUpdateRequired mWidthUpdateRequired;
     bool mbIsVerticalScrollBarVisible;
     tDLTFileWrapperPtr mpFile;
-    tRangeProperty mSearchRange;
+    tIntRangeProperty mSearchRange;
     CSearchResultModel* mpSpecificModel;
 };
 

--- a/dltmessageanalyzerplugin/src/settings/CSettingsManager.cpp
+++ b/dltmessageanalyzerplugin/src/settings/CSettingsManager.cpp
@@ -10,11 +10,11 @@
 #include <QJsonObject>
 #include <QDir>
 #include "QCoreApplication"
-
+#include <QThread>
 #include "QDebug"
 
 #include "../log/CConsoleCtrl.hpp"
-
+#include "../common/OSHelper.hpp"
 #include "CSettingsManager.hpp"
 
 static const QString sSettingsManager_Directory = QString("plugins") + QDir::separator() + "DLTMessageAnalyzerConfig";
@@ -194,7 +194,7 @@ static const tGroupedViewColumnsVisibilityMap sDefaultGroupedViewColumnsVisibili
 = fillInDefaultGroupedViewColumnsVisibilityMap();
 
 CSettingsManager::CSettingsManager():
-    mSetting_SettingsManagerVersion(createIntegralSettingsItem<tSettingsManagerVersion>(sSettingsManagerVersionKey,
+    mSetting_SettingsManagerVersion(createArithmeticSettingsItem<tSettingsManagerVersion>(sSettingsManagerVersionKey,
         [this](const tSettingsManagerVersion& data){settingsManagerVersionChanged(data);},
         [this](){tryStoreRootConfig();},
         sDefaultSettingsManagerVersion)),
@@ -206,10 +206,11 @@ CSettingsManager::CSettingsManager():
             storeRegexConfigCustomPath(regexSettingsFilePath);
         },
                                                    tAliasItemVec())),
-    mSetting_NumberOfThreads(createIntegralSettingsItem<int>(sNumberOfThreadsKey,
+    mSetting_NumberOfThreads(createRangedArithmeticSettingsItem<int>(sNumberOfThreadsKey,
         [this](const int& data){numberOfThreadsChanged(data);},
         [this](){tryStoreSettingsConfig();},
-        true)),
+        TRangedSettingItem<int>::tOptionalAllowedRange(TRangedSettingItem<int>::tAllowedRange(1, QThread::idealThreadCount())),
+        1)),
     mSetting_ContinuousSearch(createBooleanSettingsItem(sIsContinuousSearchKey,
         [this](const bool& data){continuousSearchChanged(data);},
         [this](){tryStoreSettingsConfig();},
@@ -230,10 +231,11 @@ CSettingsManager::CSettingsManager():
         [this](const bool& data){cacheEnabledChanged(data);},
         [this](){tryStoreSettingsConfig();},
         true)),
-    mSetting_CacheMaxSizeMB(createIntegralSettingsItem<tCacheSizeMB>(sCacheMaxSizeMBKey,
+    mSetting_CacheMaxSizeMB(createRangedArithmeticSettingsItem<tCacheSizeMB>(sCacheMaxSizeMBKey,
         [this](const tCacheSizeMB& data){cacheMaxSizeMBChanged(data);},
         [this](){tryStoreSettingsConfig();},
-        500)),
+        TRangedSettingItem<tCacheSizeMB>::tOptionalAllowedRange(TRangedSettingItem<tCacheSizeMB>::tAllowedRange(0, getRAMSizeUnchecked())),
+        512)),
     mSetting_RDPMode(createBooleanSettingsItem(sRDPModeKey,
         [this](const bool& data){RDPModeChanged(data);},
         [this](){tryStoreSettingsConfig();},
@@ -320,7 +322,7 @@ CSettingsManager::CSettingsManager():
         [this](const bool& data){UML_FeatureActiveChanged(data);},
         [this](){tryStoreSettingsConfig();},
         true)),
-    mSetting_UML_MaxNumberOfRowsInDiagram(createIntegralSettingsItem<int>(sUML_MaxNumberOfRowsInDiagramKey,
+    mSetting_UML_MaxNumberOfRowsInDiagram(createArithmeticSettingsItem<int>(sUML_MaxNumberOfRowsInDiagramKey,
         [this](const int& data){UML_MaxNumberOfRowsInDiagramChanged(data);},
         [this](){tryStoreRootConfig();},
         1000)),

--- a/md/in_ram_cache/in_ram_cache.md
+++ b/md/in_ram_cache/in_ram_cache.md
@@ -45,9 +45,8 @@ It allows you to:
 > **Note!**
 >
 > Be aware, that the actual RAM consumption of the cache is ~X*2.5 from what the status is showing.
-> The thing is that the cache size in the status message is measured as the sum of payloads and headers of all the messages. While the cache is stored in a slightly different data-structure.
->
-> It is one of the TODO-s to minimize this difference, but for sure it will never become 0.
+> The thing is that the cache size in the status message is measured as the sum of the sizes of the all fetched payloads and headers, which are stored as blobs. 
+> But the cache itself is stored in a slightly different, non-blob data-structure, which cause additional RAM consumption.
 
 ----
 
@@ -65,10 +64,10 @@ It allows you to:
 
 > **Note!**
 >
-> Currently plugin does not check the provided cache limit against the actual amount of RAM on the client's machine.
-> Thus, make sure that you've provide the valid input data! 
->
->Otherwise, you will reach "out of RAM" and dlt-viewer will crash ☺
+> Plugin checks the provided cache limit against the actual amount of RAM on the client's machine.
+> Still cache does not monitor the currently available amount of RAM.
+> Thus, if you will specify e.g. 32Gb as cache size having 32Gb on your machine, it might happen that you will face lack of RAM use-case and dlt-viewer will crash.
+> Be aware of that.
 
 ----
 


### PR DESCRIPTION
## [ISSUE #92][SETTINGS_MANAGER] Add possibility to check arithmetic types settings against set of allowed range of values

1. [X] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [X] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [X] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Introduction of the TOptional template class
- Refactoring of the tRange to become a template class
- Separation of cpp_standard extensions to the separate header
- Implementation of the ranged-based settings
- Switch of "NumberOfThreads" & "CacheMaxSizeMB" to the range-based ones
- Modification of README to reflect newly added logic

#### Verification criteria:

- Implementation was checked manually on Windows and Linux
- All sanity checks on Git hub were passed