### PR TITLE
[ISSUE #93][SETTINGS_MANAGER] Change location of settings from single hard-coded value to OS-specific paths

### DIFF
--- a/DLT-Message-Analyzer.pro
+++ b/DLT-Message-Analyzer.pro
@@ -146,7 +146,7 @@ win32 {
 RESOURCES += \
     dltmessageanalyzerplugin/src/resources/dltmessageanalyzer.qrc
 
-copydata.commands = $(COPY_FILE) \"$$shell_path($$PWD\thirdparty\plantuml\plantuml.jar)\" \"$$shell_path($$OUT_PWD\..\..\release\plugins)\"
+copydata.commands = $(COPY_FILE) \"$$shell_path($$PWD\thirdparty\plantuml\plantuml.jar)\" \"$$shell_path($$OUT_PWD/$(DESTDIR))\"
 first.depends = $(first) copydata
 export(first.depends)
 export(copydata.commands)

--- a/dltmessageanalyzerplugin/src/form.cpp
+++ b/dltmessageanalyzerplugin/src/form.cpp
@@ -18,6 +18,7 @@
 #include "QPropertyAnimation"
 #include "QFormLayout"
 #include "QDialogButtonBox"
+#include "QDesktopServices"
 
 #include "settings/CSettingsManager.hpp"
 #include "common/CBGColorAnimation.hpp"
@@ -196,6 +197,20 @@ Form::Form(DLTMessageAnalyzerPlugin* pDLTMessageAnalyzerPlugin, QWidget *parent)
             });
             pAction->setCheckable(true);
             pAction->setChecked(CSettingsManager::getInstance()->getUML_FeatureActive());
+            contextMenu.addAction(pAction);
+        }
+
+        contextMenu.addSeparator();
+
+        {
+            QAction* pAction = new QAction("Open settings folder", this);
+            connect(pAction, &QAction::triggered, []()
+            {
+                SEND_MSG(QString("[Form]: Attempt to open path - \"%1\"")
+                         .arg(CSettingsManager::getInstance()->getSettingsFilepath()));
+
+                QDesktopServices::openUrl( QUrl::fromLocalFile( CSettingsManager::getInstance()->getSettingsFilepath() ) );
+            });
             contextMenu.addAction(pAction);
         }
 

--- a/dltmessageanalyzerplugin/src/plant_uml/CUMLView.cpp
+++ b/dltmessageanalyzerplugin/src/plant_uml/CUMLView.cpp
@@ -118,7 +118,8 @@ mpImageViewer(nullptr),
 mpDiagramCreationSubProcess(nullptr),
 mpSaveSVGSubProcess(nullptr),
 mDiagramContent(),
-mbDiagramGenerationInProgress(false)
+mbDiagramGenerationInProgress(false),
+mLastSelectedFolder(QString(".") + QDir::separator())
 {
     mpImageViewer = new CImageViewer(this);
     setWidget(mpImageViewer);
@@ -132,7 +133,7 @@ mbDiagramGenerationInProgress(false)
             connect(pAction, &QAction::triggered, [this]()
             {
                 QString targetFilePath = QFileDialog::getSaveFileName(this, tr("Save as"),
-                                                                get_UML_File_Name(),
+                                                                mLastSelectedFolder + get_UML_File_Name(),
                                                                 tr("Portable network graphics (*.png);;"
                                                                    "Plantuml (*.puml);;"
                                                                    "Scalable vector graphics (*.svg)"));
@@ -146,6 +147,7 @@ mbDiagramGenerationInProgress(false)
                     // try to remove the file if it exists
                     if(fileInfo.exists())
                     {
+                        mLastSelectedFolder = fileInfo.dir().path() + QDir::separator();
                         QFile::remove(targetFilePath);
                     }
 

--- a/dltmessageanalyzerplugin/src/plant_uml/CUMLView.hpp
+++ b/dltmessageanalyzerplugin/src/plant_uml/CUMLView.hpp
@@ -58,6 +58,7 @@ private:
     tProcessPtr mpSaveSVGSubProcess;
     QString mDiagramContent;
     bool mbDiagramGenerationInProgress;
+    QString mLastSelectedFolder;
 };
 
 #endif // CUMLVIEW_H

--- a/dltmessageanalyzerplugin/src/settings/CSettingsManager.cpp
+++ b/dltmessageanalyzerplugin/src/settings/CSettingsManager.cpp
@@ -12,12 +12,13 @@
 #include "QCoreApplication"
 #include <QThread>
 #include "QDebug"
+#include <QStandardPaths>
 
 #include "../log/CConsoleCtrl.hpp"
 #include "../common/OSHelper.hpp"
 #include "CSettingsManager.hpp"
 
-static const QString sSettingsManager_Directory = QString("plugins") + QDir::separator() + "DLTMessageAnalyzerConfig";
+static const QString sSettingsManager_Directory = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + QDir::separator() + ".DLT-Message-Analyzer";
 static const QString sSettingsManager_Regex_SubDirectory = "regexes";
 static const QString sSettingsManager_User_SettingsFile = "user_settings.json";
 static const QString sSettingsManager_Root_SettingsFile = "root_settings.json";
@@ -1172,7 +1173,7 @@ CSettingsManager::tOperationResult CSettingsManager::backwardCompatibility_V0_V1
         SEND_MSG(QString("[CSettingsManager] Performing backward compatibility iteration from V0 to V1"));
 
         QDir dir;
-        QString configDirPath = QCoreApplication::applicationDirPath() + QDir::separator() + sSettingsManager_Directory;
+        QString configDirPath = sSettingsManager_Directory;
 
         // let's create config dir
         if(true == dir.mkpath(configDirPath))
@@ -1606,29 +1607,30 @@ const bool& CSettingsManager::getUML_Autonumber() const
 
 QString CSettingsManager::getRegexDirectory() const
 {
-    return QCoreApplication::applicationDirPath() + QDir::separator() +
-           sSettingsManager_Directory + QDir::separator() +
+    return sSettingsManager_Directory + QDir::separator() +
            sSettingsManager_Regex_SubDirectory;
 }
 
 QString CSettingsManager::getRegexDirectoryFull() const
 {
-    return QDir::toNativeSeparators( QCoreApplication::applicationDirPath() ) + QDir::separator() +
-           sSettingsManager_Directory + QDir::separator() +
+    return sSettingsManager_Directory + QDir::separator() +
            sSettingsManager_Regex_SubDirectory;
+}
+
+QString CSettingsManager::getSettingsFilepath() const
+{
+    return sSettingsManager_Directory;
 }
 
 QString CSettingsManager::getUserSettingsFilepath() const
 {
-    return QCoreApplication::applicationDirPath() + QDir::separator() +
-           sSettingsManager_Directory + QDir::separator() +
+    return sSettingsManager_Directory + QDir::separator() +
            sSettingsManager_User_SettingsFile;
 }
 
 QString CSettingsManager::getRootSettingsFilepath() const
 {
-    return QCoreApplication::applicationDirPath() + QDir::separator() +
-           sSettingsManager_Directory + QDir::separator() +
+    return sSettingsManager_Directory + QDir::separator() +
            sSettingsManager_Root_SettingsFile;
 }
 

--- a/dltmessageanalyzerplugin/src/settings/CSettingsManager.hpp
+++ b/dltmessageanalyzerplugin/src/settings/CSettingsManager.hpp
@@ -69,6 +69,7 @@ public:
     void resetGroupedViewColumnsCopyPasteMap();
     QString getRegexDirectory() const;
     QString getRegexDirectoryFull() const;
+    QString getSettingsFilepath() const;
     QString getUserSettingsFilepath() const;
     QString getRootSettingsFilepath() const;
 


### PR DESCRIPTION
## [ISSUE #93][SETTINGS_MANAGER] Change location of settings from single hard-coded value to OS-specific paths

1. [x] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [x] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [x] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Change the location of settings folder to the OS-specific user folder + "/" + "DLT-Message-Analyzer"
- Addition of the "open settings storage" context-menu item
- Addition of the "last selected folder" memory to the UML view

#### Verification criteria:

- Manually tested on Linux and Windows
- All sanity checks on Git hub were passed