### PR TITLE
[ISSUE #117][SEARCH_VIEW] Main table do not jump to a message selected within the "Search-view"

### DIFF
--- a/dltmessageanalyzerplugin/src/CDLTMessageAnalyzer.cpp
+++ b/dltmessageanalyzerplugin/src/CDLTMessageAnalyzer.cpp
@@ -1674,10 +1674,28 @@ void CDLTMessageAnalyzer::searchView_clicked_jumpTo_inMainTable(const QModelInde
 
         if(fileIdx >= 0)
         {
-            auto jumpIndex = mpMainTableView->model()->index( fileIdx, 0 );
-            mpMainTableView->setFocus();
-            mpMainTableView->scrollTo( jumpIndex, QAbstractItemView::ScrollHint::PositionAtCenter );
-            mpMainTableView->setCurrentIndex(jumpIndex);
+            auto firstVisibleColumn = -1;
+
+            const int columnsSize = mpMainTableView->model()->columnCount();
+
+
+            for(int columnCouner = 0; columnCouner < columnsSize; ++columnCouner)
+            {
+                if(false == mpMainTableView->isColumnHidden(columnCouner))
+                {
+                    firstVisibleColumn = columnCouner;
+                    break;
+                }
+            }
+
+            if(firstVisibleColumn != -1)
+            {
+                auto jumpIndex = mpMainTableView->model()->index( fileIdx, firstVisibleColumn );
+
+                mpMainTableView->setFocus();
+                mpMainTableView->scrollTo( jumpIndex, QAbstractItemView::ScrollHint::PositionAtCenter );
+                mpMainTableView->setCurrentIndex(jumpIndex);
+            }
         }
     }
 }

--- a/dltmessageanalyzerplugin/src/dltmessageanalyzerplugin.hpp
+++ b/dltmessageanalyzerplugin/src/dltmessageanalyzerplugin.hpp
@@ -17,7 +17,7 @@
 #include "common/Definitions.hpp"
 
 #define DLT_MESSAGE_ANALYZER_NAME "DLT-Message-Analyzer"
-#define DLT_MESSAGE_ANALYZER_PLUGIN_VERSION "1.0.23"
+#define DLT_MESSAGE_ANALYZER_PLUGIN_VERSION "1.0.24"
 #define DLT_MESSAGE_ANALYZER_PLUGIN_AUTHOR "Vladyslav Goncharuk <svlad1990@gmail.com>"
 
 class CDLTMessageAnalyzer;


### PR DESCRIPTION
## [ISSUE #117][SEARCH_VIEW] Main table do not jump to a message selected within the "Search-view"

1. [x] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [x] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [x] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Fix of bug described in issue #117
- Update of plugin's version to v.1.0.24

#### Verification criteria:

- Tested on Windows manually
- All sanity checks on Github were passed