### PR TITLE
[ISSUE #121][SEARCH_VIEW] Rows are not colored with the gray background, when selected to be used for UML diagrams creation

### DIFF
--- a/dltmessageanalyzerplugin/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/CMakeLists.txt
@@ -36,8 +36,8 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # required if linking to static library
 add_definitions(-DANTLR4CPP_STATIC)
 
-# using /MT flag for antlr4_runtime (for Visual C++ compilers only)
-set(ANTLR4_WITH_STATIC_CRT ON)
+# using /MD flag for antlr4_runtime (for Visual C++ compilers only)
+set(ANTLR4_WITH_STATIC_CRT OFF)
 # add external build for antlrcpp
 include(ExternalAntlr4Cpp)
 # add antrl4cpp artifacts to project environment

--- a/dltmessageanalyzerplugin/src/searchView/CSearchResultHighlightingDelegate.cpp
+++ b/dltmessageanalyzerplugin/src/searchView/CSearchResultHighlightingDelegate.cpp
@@ -340,9 +340,9 @@ void CSearchResultHighlightingDelegate::paint(QPainter *painter,
 
         auto field = static_cast<eSearchResultColumn>(index.column());
 
-        bool UML_Applicability = index.sibling(index.row(), static_cast<int>(eSearchResultColumn::UML_Applicability)).data().value<bool>();
+        Qt::CheckState UML_Applicability = index.sibling(index.row(), static_cast<int>(eSearchResultColumn::UML_Applicability)).data(Qt::CheckStateRole).value<Qt::CheckState>();
 
-        if(true == UML_Applicability)
+        if(Qt::Checked == UML_Applicability)
         {
             painter->fillRect(opt.rect, QBrush(QColor(200,200,200)));
         }


### PR DESCRIPTION
## [ISSUE #121][SEARCH_VIEW] Rows are not colored with the gray background when selected to be used for UML diagrams creation

1. [x] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [x] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [x] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Switch compilation of ANTLR to /Md in order to fix crash of debug build
- Fix of the bug with non-highlighted selected rows in the "search view"

#### Verification criteria:

- Tested manually on Windows OS
- All sanity checks on the Git hub were successfully passed