### PR TITLE
[ISSUE #123][GROUPED_VIEW] Crash during attempt to export grouped view report

### DIFF
--- a/dltmessageanalyzerplugin/src/groupedView/CGroupedViewModel.cpp
+++ b/dltmessageanalyzerplugin/src/groupedView/CGroupedViewModel.cpp
@@ -696,8 +696,7 @@ std::pair<bool /*result*/, QString /*error*/> CGroupedViewModel::exportToHTML(QS
                                 {
                                     auto variantVal = pItem->data(i);
                                     finalText.append(variantVal
-                                                     .get<QString>()
-                                                     .toHtmlEscaped());
+                                                     .get<tQStringPtrWrapper>().pString->toHtmlEscaped());
                                 }
                                     break;
                                 case eGroupedViewColumn::Messages:


### PR DESCRIPTION
## [ISSUE #123][GROUPED_VIEW] Crash during attempt to export grouped view report

1. [x] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [x] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [x] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Fix of the crash during export of the "Grouped view" report

#### Verification criteria:

- Tested manually on Windows 10 platform
- All sanity checks on Git hub were passed successfully