### PR TITLE
[ISSUE #125][GENERAL] Project build fails with Qt. 5.15.0 and higher

### DIFF
--- a/dltmessageanalyzerplugin/src/log/CConsoleInputProcessor.cpp
+++ b/dltmessageanalyzerplugin/src/log/CConsoleInputProcessor.cpp
@@ -682,7 +682,14 @@ bool CConsoleInputProcessor::eventFilter(QObject* pObj, QEvent* pEvent)
                 SEND_MSG(QString("| ").append(text));
 
                 // let's split input text into function name, and its parameters
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+                auto stirngList = text.split(" -", QString::SplitBehavior::SkipEmptyParts);
+#else
                 auto stirngList = text.split(" -", Qt::SkipEmptyParts);
+#endif
+
+
 
                 if(false == stirngList.empty())
                 {
@@ -699,7 +706,11 @@ bool CConsoleInputProcessor::eventFilter(QObject* pObj, QEvent* pEvent)
 
                         for(const auto& paramCandidate : stirngList)
                         {
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+                            QStringList parsedParam = paramCandidate.split("=", QString::SplitBehavior::SkipEmptyParts);
+#else
                             QStringList parsedParam = paramCandidate.split("=", Qt::SkipEmptyParts);
+#endif
 
                             if(parsedParam.size() == 2)
                             {

--- a/md/installation_guide/installation_guide.md
+++ b/md/installation_guide/installation_guide.md
@@ -6,13 +6,13 @@
 
 - Clone the dlt-viewer project from the **[following location]( https://github.com/GENIVI/dlt-viewer )**.
 
+> git clone git@github.com:GENIVI/dlt-viewer.git
+
 ----
 
 > **Note!**
 > 
 > Currently plugin can be built against the v2.20.1 release.
->
-> The build under the v2.20.1 is also supported.
 >
 > The build under the v2.19.0 is also supported. But you will need to use the compatibility mode. Such an option is described below. Search for the "PLUGIN_INTERFACE_VERSION" keyword.
 >
@@ -20,7 +20,45 @@
 
 ----
 
-- After dlt-viewer is cloned, specify the location of CMake in QT Creator:
+- Clone DLT-Message-Analyzer's git repository ( the one which you are observing right now ) as a nested one inside the **"./dlt-viewer/plugin"** location.
+Your target path to the plugin should look like **"./dlt-viewer/plugin/DLT-Message-Analyzer"**:
+
+>```
+> cd ./dlt-viewer/plugin/DLT-Message-Analyzer
+> git clone git@github.com:svlad-90/DLT-Message-Analyzer.git
+> ```
+
+![Screenshot of DLT Message Analyzer plugin location inside the dlt-viewer project](./installation_guide_plugin_location.png)
+
+----
+
+- modify also the **"./dlt-viewer/plugin/CMakeLists.txt"**:
+
+<pre>add_subdirectory(DLT-Message-Analyzer/dltmessageanalyzerplugin/src)</pre>
+
+![Screenshot of plugin.pro cmakelists.txt modification](./installation_guide_cmakelists_modification.png)
+
+----
+
+### Linux console build
+
+- Open console in the "./dlt-viewer" folder:
+
+![Screenshot of console](./installation_guide_console.png)
+
+- Run the following set of commands in it:
+
+<pre>mkdir build
+cd build
+cmake ..
+make -j4
+</pre>
+
+----
+
+### Qt Creator IDE set up
+
+- Specify the location of CMake in QT Creator:
 
 ![Screenshot of "Specify CMake location" menu in QT Creator](./installation_guide_cmake_location.png)
 
@@ -70,13 +108,6 @@ Afterward, open the dlt-viewer's CMake project, which is located in the root of 
 
 ----
 
-- Clone DLT-Message-Analyzer's git repository ( the one which you are observing right now ) as a nested one inside the **"./dlt-viewer/plugin"** location.
-Your target path to the plugin should look like **"./dlt-viewer/plugin/DLT-Message-Analyzer"**:
-
-![Screenshot of DLT Message Analyzer plugin location inside the dlt-viewer project](./installation_guide_plugin_location.png)
-
-----
-
 ## qmake *.pro based build
 
 Such a build option was dropped.
@@ -85,28 +116,6 @@ Thus the decision was finally made to support ONLY CMake builds for all supporte
 As of now, they are Linux and Windows.
 
 ----
-
-- modify also the **"./dlt-viewer/plugin/CMakeLists.txt"**:
-
-<pre>add_subdirectory(DLT-Message-Analyzer/dltmessageanalyzerplugin/src)</pre>
-
-![Screenshot of plugin.pro cmakelists.txt modification](./installation_guide_cmakelists_modification.png)
-
-----
-
-### Linux console build
-
-- Open console in the "./dlt-viewer" folder:
-
-![Screenshot of console](./installation_guide_console.png)
-
-- Run the following set of commands in it:
-
-<pre>mkdir build
-cd build
-cmake ..
-make -j4
-</pre>
 
 ### Linux and Windows QT creator build
 
@@ -127,6 +136,19 @@ make -j4
 ![Screenshot of build button in QT Creator](./installation_guide_build.png)
 
 ----
+
+### Run dlt-viewer and enable the plugin
+
+- Proceed to the build's artifacts folder and run the dlt-viewer. It should already include and load the dynamic library of the DLT-Message-Analyzer plugin
+- Enable and show the DLT-Message-Analyzer plugin:
+
+![Screenshot of enabling the plugin](./installation_guide_enable_plugin.png)
+
+----
+
+### Build dependencies and settings
+
+#### Build dependencies
 
 > **Note!** 
 > 
@@ -151,10 +173,16 @@ make -j4
 
 ----
 
-- Proceed to the build's artifacts folder and run the dlt-viewer. It should already include and load the dynamic library of the DLT-Message-Analyzer plugin
-- Enable and show the DLT-Message-Analyzer plugin:
+#### Build settings
 
-![Screenshot of enabling the plugin](./installation_guide_enable_plugin.png)
+> **Note!** 
+> 
+> If build fails due to missing qt5serialport5 package, perform the following commands:
+>```
+> sudo apt-get install libqt5serialport5
+> sudo apt-get install libqt5serialport5-dev
+>```
+>
 
 ----
 


### PR DESCRIPTION
## [ISSUE #125][GENERAL] Project build fails with Qt. 5.15.0 and higher

1. [x] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [x] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [x] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Fix build via addition of conditional compilation code
- Refactoring of the installation guide so that it becomes more transparent

#### Verification criteria:

- Build tested on Ubuntu 20.04 LTS
- All Git hub sanity checks were passed successfully