### PR TITLE
[ISSUE #127][SEARCH_VIEW] Representation of heavily colored strings in search view is consuming a lot of CPU

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -52,7 +52,9 @@ jobs:
       
     # Add jom to path
     - name: Add jom to path
-      run: echo "::add-path::D:/a/${{ github.event.repository.name }}/tools/jom/"
+      run: |
+           echo "D:/a/${{ github.event.repository.name }}/tools/jom/" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      shell: powershell
 
     # Checkout dlt-viewer's revision 2.20.1
     - name: Checkout of the dlt-viewer

--- a/dltmessageanalyzerplugin/src/dltWrappers/CDLTMsgWrapper.cpp
+++ b/dltmessageanalyzerplugin/src/dltWrappers/CDLTMsgWrapper.cpp
@@ -48,6 +48,13 @@ mInitialMsgSize(0u)
     //qDebug() << "CDLTMsgWrapper::CDLTMsgWrapper: number of instances - " << sInstanceCounter;
 }
 
+static const QRegularExpression sReplaceRegex("\n|\\x{0000}|\\x{0001}|\\x{0002}|\\x{0003}|\\x{0004}|\\x{0005}"
+                                 "|\\x{0006}|\\x{0007}|\\x{0008}|\\x{0009}|\\x{000A}|\\x{000B}"
+                                 "|\\x{000C}|\\x{000D}|\\x{000E}|\\x{000F}|\\x{0010}|\\x{0011}"
+                                 "|\\x{0012}|\\x{0013}|\\x{0014}|\\x{0015}|\\x{0016}|\\x{0017}"
+                                 "|\\x{0018}|\\x{0019}|\\x{001A}|\\x{001B}|\\x{001C}|\\x{001D}"
+                                 "|\\x{001E}|\\x{001F}");
+
 CDLTMsgWrapper::CDLTMsgWrapper(const QDltMsg& msg):
 mMicroseconds(msg.getMicroseconds()),
 mTimestamp(msg.getTimestamp()),
@@ -60,7 +67,7 @@ mTime(msg.getTime()),
 mEcuidUTF8(msg.getEcuid().toUtf8()),
 mApidUTF8(msg.getApid().toUtf8()),
 mCtidUTF8(msg.getCtid().toUtf8()),
-mPayloadUTF8(msg.toStringPayload().replace("\n", "").toUtf8()),
+mPayloadUTF8(msg.toStringPayload().replace(sReplaceRegex, "").toUtf8()),
 mType(msg.getType()),
 mMode(msg.getMode()),
 mCtrlReturnType(msg.getCtrlReturnType()),

--- a/dltmessageanalyzerplugin/src/searchView/CSearchResultModel.cpp
+++ b/dltmessageanalyzerplugin/src/searchView/CSearchResultModel.cpp
@@ -25,9 +25,9 @@ void CSearchResultModel::setFile(const tDLTFileWrapperPtr& pFile)
     mpFile = pFile;
 }
 
-void CSearchResultModel::updateView()
+void CSearchResultModel::updateView(const int& fromRow)
 {
-    emit dataChanged( index(0,0), index(static_cast<int>(mFoundMatchesPack.matchedItemVec.size()), 1) );
+    emit dataChanged( index(fromRow,0), index(static_cast<int>(mFoundMatchesPack.matchedItemVec.size()), columnCount(QModelIndex())) );
     emit layoutChanged();
 }
 
@@ -275,14 +275,13 @@ std::pair<bool, tIntRange> CSearchResultModel::addNextMessageIdxVec(const tFound
     if(false == foundMatchesPack.matchedItemVec.empty())
     {
         beginInsertRows(QModelIndex(), static_cast<int>(mFoundMatchesPack.matchedItemVec.size()),
-                        static_cast<int>(mFoundMatchesPack.matchedItemVec.size()));
+                        static_cast<int>(mFoundMatchesPack.matchedItemVec.size() + foundMatchesPack.matchedItemVec.size() - 1));
         result.second.from = static_cast<int>(mFoundMatchesPack.matchedItemVec.size());
         mFoundMatchesPack.matchedItemVec.insert(mFoundMatchesPack.matchedItemVec.end(),
                                                 foundMatchesPack.matchedItemVec.begin(),
                                                 foundMatchesPack.matchedItemVec.end());
         result.second.to = static_cast<int>(mFoundMatchesPack.matchedItemVec.size() - 1);
         endInsertRows();
-        updateView();
 
         result.first = true;
     }

--- a/dltmessageanalyzerplugin/src/searchView/CSearchResultModel.hpp
+++ b/dltmessageanalyzerplugin/src/searchView/CSearchResultModel.hpp
@@ -22,7 +22,7 @@ public:
     CSearchResultModel(QObject *parent=nullptr);
 
     void setFile(const tDLTFileWrapperPtr& pFile);
-    void updateView();
+    void updateView(const int& fromRow = 0);
     void resetData();
     int getFileIdx( const QModelIndex& idx ) const;
 


### PR DESCRIPTION
## [ISSUE #127][SEARCH_VIEW] Representation of heavily colored strings in search view is consuming a lot of CPU

1. [x] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [x] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [x] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Addition of the elimination of all UTF control characters from the created wrapped dlt-messages. Those characters were causing slow performance of some of the QT's API calls ( e.g. QFontMetrics::horizontalAdvance )
- Addition of the profiling to the "search view's" highlighting delegate ( turned off in production builds )
- Minor optimization regarding how the search model triggers updates of the "Search view"

#### Verification criteria:

- Manual verification on Windows OS
- All sanity checks on GitHub were passed