### PR TITLE
[ISSUE #149] [UML_VIEW] Bug-fixing of the UML view

### DIFF
--- a/dltmessageanalyzerplugin/src/common/Definitions.hpp
+++ b/dltmessageanalyzerplugin/src/common/Definitions.hpp
@@ -536,6 +536,7 @@ struct tUMLInfo
     bool bUMLConstraintsFulfilled = false;
     bool bApplyForUMLCreation = false;
     tUMLDataMap UMLDataMap;
+    bool bContains_Req_Resp_Ev = false;
 };
 
 struct tItemMetadata
@@ -551,7 +552,14 @@ struct tItemMetadata
                                  const QVector<QColor>& gradientColors,
                                  const tRegexScriptingMetadata& regexScriptingMetadata,
                                  tTreeItemSharedPtr pTree = nullptr);
-    tTreeItemSharedPtr updateUMLInfo(const tFoundMatches& foundMatches,
+
+    struct tUpdateUMLInfoResult
+    {
+        tTreeItemSharedPtr pTreeItem;
+        bool bUML_Req_Res_Ev_DuplicateFound = false;
+    };
+
+    tUpdateUMLInfoResult updateUMLInfo(const tFoundMatches& foundMatches,
                        const tRegexScriptingMetadata& regexScriptingMetadata,
                        tTreeItemSharedPtr pTree = nullptr);
     tMsgId msgId;

--- a/dltmessageanalyzerplugin/src/common/PCRE/PCREHelper.cpp
+++ b/dltmessageanalyzerplugin/src/common/PCRE/PCREHelper.cpp
@@ -2,10 +2,6 @@
 
 #include "QString"
 
-#ifdef DEBUG_BUILD
-#include "QElapsedTimer"
-#endif
-
 #include "QLocale"
 
 #include "PCRELexer.h"
@@ -15,6 +11,10 @@
 #include "../CTreeItem.hpp"
 #include "components/log/api/CLog.hpp"
 #include "PCREHelper.hpp"
+
+#ifdef DEBUG_BUILD
+#include "QElapsedTimer"
+#endif
 
 using namespace std;
 using namespace antlr4;

--- a/dltmessageanalyzerplugin/src/components/analyzer/api/Definitions.hpp
+++ b/dltmessageanalyzerplugin/src/components/analyzer/api/Definitions.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "stdint.h"
+
+#include "QRegularExpression"
+
+#include "common/Definitions.hpp"
+
+struct tRequestParameters
+{
+    tRequestParameters();
+
+    /**
+     * @param pClient - client, which should be notified about the progress
+     * @param pFile - file, which is used for analysis
+     * @param fromMessage - from which message to analyze
+     * @param numberOfMessages - until which message to analyze
+     * @param regex - regex, to be used for analysis
+     * @param numberOfThreads - number of threads to be used for analysis
+     * @param regexScriptingMetadata - scripting metadata
+     * @param isContinuous - whether search is continuous. This parameter can be ignored by one-shot implementations
+     */
+    tRequestParameters(
+    const tFileWrapperPtr& pFile_,
+    const int& fromMessage_,
+    const int& numberOfMessages_,
+    const QRegularExpression& regex_,
+    const int& numberOfThreads_,
+    bool isContinuous_);
+
+    tFileWrapperPtr pFile;
+    int fromMessage;
+    int numberOfMessages;
+    QRegularExpression regex;
+    int numberOfThreads;
+    bool isContinuous;
+};
+
+Q_DECLARE_METATYPE(tRequestParameters)
+
+struct tProgressNotificationData
+{
+    tProgressNotificationData();
+
+   /*
+    * @param requestId - id of the request, about which we notify the client
+    * @param requestState - the state of the request
+    * @param progress - progress in percents
+    * @param processedMatches - found matches
+    * @param isContinuous - whether analysis is continuous.
+    */
+    tProgressNotificationData(
+    const tRequestId& requestId_,
+    const eRequestState& requestState_,
+    const int8_t& progress_,
+    const tFoundMatchesPack& processedMatches_,
+    bool bUML_Req_Res_Ev_DuplicateFound_);
+
+    tRequestId requestId;
+    eRequestState requestState;
+    int8_t progress;
+    tFoundMatchesPack processedMatches;
+    bool bUML_Req_Res_Ev_DuplicateFound;
+};
+
+Q_DECLARE_METATYPE(tProgressNotificationData)

--- a/dltmessageanalyzerplugin/src/components/analyzer/api/IDLTMessageAnalyzerController.hpp
+++ b/dltmessageanalyzerplugin/src/components/analyzer/api/IDLTMessageAnalyzerController.hpp
@@ -7,7 +7,7 @@
 
 #include <QObject>
 
-#include "common/Definitions.hpp"
+#include "Definitions.hpp"
 
 //Forward declarations
 class IDLTMessageAnalyzerControllerConsumer;
@@ -30,23 +30,13 @@ public:
     /**
      * @brief requestAnalyze - used to triger analysis
      * @param pClient - client, which should be notified about the progress
-     * @param pFile - file, which is used for analysis
-     * @param fromMessage - from which message to analyze
-     * @param numberOfMessages - until which message to analyze
-     * @param regex - regex, to be used for analysis
-     * @param numberOfThreads - number of threads to be used for analysis
-     * @param regexScriptingMetadata - scripting metadata
-     * @param isContinuous - whether search is continuous. This parameter can be ignored by one-shot implementations
+     * @param requestParameters - inout request parameters
+     * @param regexScriptingMetadata - regex scripting metadata
      * @return - request id, if search was successfully started. Or INVALID_REQUEST_ID otherwise
      */
     virtual tRequestId requestAnalyze( const std::weak_ptr<IDLTMessageAnalyzerControllerConsumer>& pClient,
-                                       const tFileWrapperPtr& pFile,
-                                       const int& fromMessage,
-                                       const int& numberOfMessages,
-                                       const QRegularExpression& regex,
-                                       const int& numberOfThreads,
-                                       const tRegexScriptingMetadata& regexScriptingMetadata,
-                                       bool isContinuous)=0;
+                                       const tRequestParameters& requestParameters,
+                                       const tRegexScriptingMetadata& regexScriptingMetadata )=0;
 
     /**
      * @brief cancelRequest - used to stop previously started analysis iteration
@@ -72,18 +62,10 @@ public:
 signals:
     /**
      * @brief progressNotification - signal, which notifies client about the analysis progress.
-     * @param requestId - id of the request, about which we notify the client
-     * @param requestState - the state of the request
-     * @param progress - progress in percents
-     * @param processedMatches - found matches
-     * @param isContinuous - whether analysis is continuous.
+     * @param progressNotificationData - progress notification data
      * Client might not remember about this fact, so we provide this information back to the client, to simplify the client's logic.
      */
-    void progressNotification( const tRequestId& requestId,
-                                       const eRequestState& requestState,
-                                       const int8_t& progress,
-                                       const tFoundMatchesPack& processedMatches,
-                                       bool isContinuous );
+    void progressNotification( const tProgressNotificationData& progressNotificationData );
 };
 
 typedef std::shared_ptr<IDLTMessageAnalyzerController> tDLTMessageAnalyzerControllerPtr;

--- a/dltmessageanalyzerplugin/src/components/analyzer/api/IDLTMessageAnalyzerControllerConsumer.hpp
+++ b/dltmessageanalyzerplugin/src/components/analyzer/api/IDLTMessageAnalyzerControllerConsumer.hpp
@@ -7,7 +7,7 @@
 
 #include <QObject>
 
-#include "common/Definitions.hpp"
+#include "Definitions.hpp"
 
 //Forward declarations
 
@@ -29,19 +29,11 @@ public:
     virtual ~IDLTMessageAnalyzerControllerConsumer();
 
 public slots:
-    virtual void progressNotification( const tRequestId& requestId,
-                                       const eRequestState& requestState,
-                                       const int8_t& progress,
-                                       const tFoundMatchesPack& processedMatches)=0;
+    virtual void progressNotification( const tProgressNotificationData& progressNotificationData )=0;
 
 protected:
     IDLTMessageAnalyzerControllerConsumer( const std::weak_ptr<IDLTMessageAnalyzerController>& pController );
-    tRequestId requestAnalyze( const tFileWrapperPtr& pFile,
-                               const int& fromMessage,
-                               const int& numberOfMessages,
-                               const QRegularExpression& regex,
-                               const int& numberOfThreads,
-                               bool isContinuous,
+    tRequestId requestAnalyze( const tRequestParameters& requestParameters,
                                bool bUMLFeatureActive );
     void cancelRequest( const tRequestId& requestId );
 

--- a/dltmessageanalyzerplugin/src/components/analyzer/src/CContinuousAnalyzer.hpp
+++ b/dltmessageanalyzerplugin/src/components/analyzer/src/CContinuousAnalyzer.hpp
@@ -21,16 +21,10 @@ class CSubConsumer : public IDLTMessageAnalyzerControllerConsumer
 {
    Q_OBJECT
 public:
-   typedef std::function<void(const tRequestId&,
-                              const eRequestState&,
-                              const int8_t&,
-                              const tFoundMatchesPack&)> tCallback;
+   typedef std::function<void(const tProgressNotificationData&)> tCallback;
    CSubConsumer(const tDLTMessageAnalyzerControllerPtr& pController);
    void setCallback(const tCallback& callback);
-   void progressNotification( const tRequestId& requestId,
-                              const eRequestState& requestState,
-                              const int8_t& progress,
-                              const tFoundMatchesPack& processedMatches) override;
+   void progressNotification( const tProgressNotificationData& progressNotificationData ) override;
 private:
    tCallback mCallback;
 };
@@ -53,13 +47,8 @@ public:
      * @brief requestAnalyze - check IDLTMessageAnalyzerController for details
      */
     tRequestId requestAnalyze( const std::weak_ptr<IDLTMessageAnalyzerControllerConsumer>& pClient,
-                               const tFileWrapperPtr& pFile,
-                               const int& fromMessage,
-                               const int& numberOfMessages,
-                               const QRegularExpression& regex,
-                               const int& numberOfThreads,
-                               const tRegexScriptingMetadata& regexScriptingMetadata,
-                               bool isContinuous ) override;
+                               const tRequestParameters& requestParameters,
+                               const tRegexScriptingMetadata& regexScriptingMetadata ) override;
 
     /**
      * @brief requestAnalyze - check IDLTMessageAnalyzerController for details
@@ -76,10 +65,7 @@ private:// methods
     typedef QMap<tRequestId, tRequestData> tRequestDataMap;
 
     void triggerContinuousAnalysisIteration(const tRequestDataMap::iterator& inputIt);
-    void progressNotification(const tRequestId& requestId,
-                              const eRequestState& requestState,
-                              const int8_t& progress,
-                              const tFoundMatchesPack& processedMatches);
+    void progressNotification(const tProgressNotificationData& progressNotificationData);
 
 private:// fields
     std::shared_ptr<IDLTMessageAnalyzerControllerConsumer> mpSubConsumer;

--- a/dltmessageanalyzerplugin/src/components/analyzer/src/CDLTRegexAnalyzerWorker.hpp
+++ b/dltmessageanalyzerplugin/src/components/analyzer/src/CDLTRegexAnalyzerWorker.hpp
@@ -12,6 +12,7 @@
 #include <QRegularExpression>
 
 #include "common/Definitions.hpp"
+#include "DefinitionsInternal.hpp"
 #include "../api/IDLTMessageAnalyzerController.hpp"
 
 #include "components/settings/api/CSettingsManagerClient.hpp"
@@ -28,24 +29,14 @@ class CDLTRegexAnalyzerWorker : public QObject,
     Q_OBJECT
 public:
 
-    enum class ePortionAnalysisState
-    {
-        ePortionAnalysisState_SUCCESSFUL,
-        ePortionAnalysisState_ERROR
-    };
-
     CDLTRegexAnalyzerWorker(const tSettingsManagerPtr& pSettingsManager);
     tWorkerId getWorkerId() const;
 
 public slots:
-    void analyzePortion( const tRequestId& requestId,
-                         const tProcessingStrings& processingStrings,
-                         const QRegularExpression& regex,
-                         const tRegexScriptingMetadata& regexMetadata,
-                         const tWorkerThreadCookie& workerThreadCookie );
+    void analyzePortion( const tAnalyzePortionData& analyzePortionData );
 
 signals:
-    void portionAnalysisFinished( const tRequestId& requestId, int numberOfProcessedString, ePortionAnalysisState portionAnalysisState, const tFoundMatchesPack& processedMatches, const tWorkerId& workerId, const tWorkerThreadCookie& workerThreadCookie);
+    void portionAnalysisFinished( const tPortionRegexAnalysisFinishedData& portionRegexAnalysisFinishedData );
 
 private: // members
     tWorkerId mWorkerId;

--- a/dltmessageanalyzerplugin/src/components/analyzer/src/CMTAnalyzer.hpp
+++ b/dltmessageanalyzerplugin/src/components/analyzer/src/CMTAnalyzer.hpp
@@ -9,7 +9,7 @@
 
 #include <QRegularExpression>
 
-#include "common/Definitions.hpp"
+#include "../api/Definitions.hpp"
 
 #include "../api/IDLTMessageAnalyzerController.hpp"
 #include "CDLTRegexAnalyzerWorker.hpp"
@@ -33,23 +33,13 @@ class CMTAnalyzer: public IDLTMessageAnalyzerController,
 
         //IDLTMessageAnalyzerController implementation
         tRequestId requestAnalyze( const std::weak_ptr<IDLTMessageAnalyzerControllerConsumer>& pClient,
-                                   const tFileWrapperPtr& pFile,
-                                   const int& fromMessage,
-                                   const int& numberOfMessages,
-                                   const QRegularExpression& regex,
-                                   const int& numberOfThreads,
-                                   const tRegexScriptingMetadata& regexScriptingMetadata,
-                                   bool isContinuous ) override;
+                                   const tRequestParameters& requestParameters,
+                                   const tRegexScriptingMetadata& regexScriptingMetadata ) override;
         void cancelRequest( const std::weak_ptr<IDLTMessageAnalyzerControllerConsumer>& pClient, const tRequestId& requestId ) override;
         int getMaximumNumberOfThreads() const override;
 
 private slots:
-    void portionRegexAnalysisFinished( const tRequestId& requestId,
-                                       int numberOfProcessedString,
-                                       CDLTRegexAnalyzerWorker::ePortionAnalysisState portionAnalysisState,
-                                       const tFoundMatchesPack& processedMatches,
-                                       const tWorkerId& workerId,
-                                       const tWorkerThreadCookie& workerThreadCookie );
+    void portionRegexAnalysisFinished( const tPortionRegexAnalysisFinishedData& portionRegexAnalysisFinishedData );
 
 private: // methods
 
@@ -72,6 +62,7 @@ private: // methods
         int numberOfThreads; // number of threads, to be used for analysis
         int fromMessage; // from which message to start analysis
         tWorkerThreadCookie workerThreadCookieCounter;
+        bool bUML_Req_Res_Ev_DuplicateFound = false;
 
         struct tPendingResultsItem
         {

--- a/dltmessageanalyzerplugin/src/components/analyzer/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/components/analyzer/src/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library(DMA_analyzer STATIC
     CContinuousAnalyzer.cpp
     CDLTRegexAnalyzerWorker.cpp
     CAnalyzerComponent.cpp
+    Definitions.cpp
+    DefinitionsInternal.cpp
     ${PROCESSED_MOCS}
     )
 

--- a/dltmessageanalyzerplugin/src/components/analyzer/src/Definitions.cpp
+++ b/dltmessageanalyzerplugin/src/components/analyzer/src/Definitions.cpp
@@ -1,0 +1,50 @@
+#include "../api/Definitions.hpp"
+
+tRequestParameters::tRequestParameters():
+pFile(nullptr),
+fromMessage(0),
+numberOfMessages(0),
+regex(),
+numberOfThreads(0),
+isContinuous(false)
+{
+}
+
+tRequestParameters::tRequestParameters(
+const tFileWrapperPtr& pFile_,
+const int& fromMessage_,
+const int& numberOfMessages_,
+const QRegularExpression& regex_,
+const int& numberOfThreads_,
+bool isContinuous_):
+pFile(pFile_),
+fromMessage(fromMessage_),
+numberOfMessages(numberOfMessages_),
+regex(regex_),
+numberOfThreads(numberOfThreads_),
+isContinuous(isContinuous_)
+{
+}
+
+tProgressNotificationData::tProgressNotificationData():
+requestId(INVALID_REQUEST_ID),
+requestState(eRequestState::ERROR_STATE),
+progress(0),
+processedMatches(),
+bUML_Req_Res_Ev_DuplicateFound(false)
+{
+}
+
+tProgressNotificationData::tProgressNotificationData(
+const tRequestId& requestId_,
+const eRequestState& requestState_,
+const int8_t& progress_,
+const tFoundMatchesPack& processedMatches_,
+bool bUML_Req_Res_Ev_DuplicateFound_):
+requestId(requestId_),
+requestState(requestState_),
+progress(progress_),
+processedMatches(processedMatches_),
+bUML_Req_Res_Ev_DuplicateFound(bUML_Req_Res_Ev_DuplicateFound_)
+{
+}

--- a/dltmessageanalyzerplugin/src/components/analyzer/src/DefinitionsInternal.cpp
+++ b/dltmessageanalyzerplugin/src/components/analyzer/src/DefinitionsInternal.cpp
@@ -1,0 +1,49 @@
+#include "DefinitionsInternal.hpp"
+
+tPortionRegexAnalysisFinishedData::tPortionRegexAnalysisFinishedData():
+requestId(INVALID_REQUEST_ID),
+numberOfProcessedString(),
+portionAnalysisState(),
+processedMatches(),
+workerId(),
+workerThreadCookie(),
+bUML_Req_Res_Ev_DuplicateFound(false)
+{}
+
+tPortionRegexAnalysisFinishedData::tPortionRegexAnalysisFinishedData(
+const tRequestId& requestId_,
+int numberOfProcessedString_,
+ePortionAnalysisState portionAnalysisState_,
+const tFoundMatchesPack& processedMatches_,
+const tWorkerId& workerId_,
+const tWorkerThreadCookie& workerThreadCookie_,
+bool bUML_Req_Res_Ev_DuplicateFound_):
+requestId(requestId_),
+numberOfProcessedString(numberOfProcessedString_),
+portionAnalysisState(portionAnalysisState_),
+processedMatches(processedMatches_),
+workerId(workerId_),
+workerThreadCookie(workerThreadCookie_),
+bUML_Req_Res_Ev_DuplicateFound(bUML_Req_Res_Ev_DuplicateFound_)
+{}
+
+tAnalyzePortionData::tAnalyzePortionData():
+requestId(INVALID_REQUEST_ID),
+processingStrings(),
+regex(),
+regexMetadata(),
+workerThreadCookie()
+{}
+
+tAnalyzePortionData::tAnalyzePortionData(
+const tRequestId& requestId_,
+const tProcessingStrings& processingStrings_,
+const QRegularExpression& regex_,
+const tRegexScriptingMetadata& regexMetadata_,
+const tWorkerThreadCookie& workerThreadCookie_ ):
+requestId(requestId_),
+processingStrings(processingStrings_),
+regex(regex_),
+regexMetadata(regexMetadata_),
+workerThreadCookie(workerThreadCookie_)
+{}

--- a/dltmessageanalyzerplugin/src/components/analyzer/src/DefinitionsInternal.hpp
+++ b/dltmessageanalyzerplugin/src/components/analyzer/src/DefinitionsInternal.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "QRegularExpression"
+
+#include "common/Definitions.hpp"
+
+enum class ePortionAnalysisState
+{
+    ePortionAnalysisState_SUCCESSFUL,
+    ePortionAnalysisState_ERROR
+};
+
+struct tPortionRegexAnalysisFinishedData
+{
+    tPortionRegexAnalysisFinishedData();
+
+    tPortionRegexAnalysisFinishedData(
+    const tRequestId& requestId_,
+    int numberOfProcessedString_,
+    ePortionAnalysisState portionAnalysisState_,
+    const tFoundMatchesPack& processedMatches_,
+    const tWorkerId& workerId_,
+    const tWorkerThreadCookie& workerThreadCookie_,
+    bool bUML_Req_Res_Ev_DuplicateFound_);
+
+    tRequestId requestId;
+    int numberOfProcessedString;
+    ePortionAnalysisState portionAnalysisState;
+    tFoundMatchesPack processedMatches;
+    tWorkerId workerId;
+    tWorkerThreadCookie workerThreadCookie;
+    bool bUML_Req_Res_Ev_DuplicateFound;
+};
+
+Q_DECLARE_METATYPE(tPortionRegexAnalysisFinishedData)
+
+struct tAnalyzePortionData
+{
+    tAnalyzePortionData();
+
+    tAnalyzePortionData(
+    const tRequestId& requestId_,
+    const tProcessingStrings& processingStrings_,
+    const QRegularExpression& regex_,
+    const tRegexScriptingMetadata& regexMetadata_,
+    const tWorkerThreadCookie& workerThreadCookie_ );
+
+    tRequestId requestId;
+    tProcessingStrings processingStrings;
+    QRegularExpression regex;
+    tRegexScriptingMetadata regexMetadata;
+    tWorkerThreadCookie workerThreadCookie;
+};
+
+Q_DECLARE_METATYPE(tAnalyzePortionData)

--- a/dltmessageanalyzerplugin/src/components/analyzer/src/IDLTMessageAnalyzerController.cpp
+++ b/dltmessageanalyzerplugin/src/components/analyzer/src/IDLTMessageAnalyzerController.cpp
@@ -17,15 +17,10 @@ PUML_PACKAGE_BEGIN(DMA_Analyzer_API)
         PUML_INHERITANCE_CHECKED(QObject, extends)
         PUML_PURE_VIRTUAL_METHOD( +, void cancelRequest( const std::weak_ptr<IDLTMessageAnalyzerControllerConsumer>& pClient, const tRequestId& requestId ) )
         PUML_PURE_VIRTUAL_METHOD( +, tRequestId requestAnalyze( const std::weak_ptr<IDLTMessageAnalyzerControllerConsumer>& pClient,
-                                                               const tFileWrapperPtr& pFile,
-                                                               const int& fromMessage,
-                                                               const int& numberOfMessages,
-                                                               const QRegularExpression& regex,
-                                                               const int& numberOfThreads,
-                                                               const tRegexScriptingMetadata& regexScriptingMetadata,
-                                                               bool isContinuous) )
+                                                                const tRequestParameters& requestParameters ) )
         PUML_PURE_VIRTUAL_METHOD( +, void cancelRequest( const std::weak_ptr<IDLTMessageAnalyzerControllerConsumer>& pClient, const tRequestId& requestId ) )
         PUML_PURE_VIRTUAL_METHOD( +, int getMaximumNumberOfThreads() const )
+        PUML_METHOD( +, signal void progressNotification( const tProgressNotificationData& progressNotificationData ) )
         PUML_USE_DEPENDENCY_CHECKED(IFileWrapper, 1, 1, uses)
     PUML_ABSTRACT_CLASS_END()
 PUML_PACKAGE_END()

--- a/dltmessageanalyzerplugin/src/components/analyzer/src/IDLTMessageAnalyzerControllerConsumer.cpp
+++ b/dltmessageanalyzerplugin/src/components/analyzer/src/IDLTMessageAnalyzerControllerConsumer.cpp
@@ -25,12 +25,7 @@ IDLTMessageAnalyzerControllerConsumer::IDLTMessageAnalyzerControllerConsumer( co
 
 }
 
-tRequestId IDLTMessageAnalyzerControllerConsumer::requestAnalyze( const tFileWrapperPtr& pFile,
-                                                                  const int& fromMessage,
-                                                                  const int& numberOfMessages,
-                                                                  const QRegularExpression& regex,
-                                                                  const int& numberOfThreads,
-                                                                  bool isContinuous,
+tRequestId IDLTMessageAnalyzerControllerConsumer::requestAnalyze( const tRequestParameters& requestParameters,
                                                                   bool bUMLFeatureActive )
 {
     tRequestId requestId = INVALID_REQUEST_ID;
@@ -39,7 +34,7 @@ tRequestId IDLTMessageAnalyzerControllerConsumer::requestAnalyze( const tFileWra
     {
         tRegexScriptingMetadata regexMetadata;
 
-        bool bParseResult = regexMetadata.parse(regex, bUMLFeatureActive);
+        bool bParseResult = regexMetadata.parse(requestParameters.regex, bUMLFeatureActive);
 
         if(false == bParseResult)
         {
@@ -61,7 +56,7 @@ tRequestId IDLTMessageAnalyzerControllerConsumer::requestAnalyze( const tFileWra
             }
         }
 
-        requestId = mpController.lock()->requestAnalyze(shared_from_this(), pFile, fromMessage, numberOfMessages, regex, numberOfThreads, regexMetadata, isContinuous);
+        requestId = mpController.lock()->requestAnalyze(shared_from_this(), requestParameters, regexMetadata);
     }
 
     return requestId;
@@ -82,16 +77,8 @@ PUML_PACKAGE_BEGIN(DMA_Analyzer_API)
     PUML_ABSTRACT_CLASS_BEGIN_CHECKED(IDLTMessageAnalyzerControllerConsumer)
         PUML_INHERITANCE_CHECKED(QObject, extends)
         PUML_INHERITANCE_CHECKED(std::enable_shared_from_this<IDLTMessageAnalyzerControllerConsumer>, extends)
-        PUML_PURE_VIRTUAL_METHOD( +, void progressNotification( const tRequestId& requestId,
-                                                                const eRequestState& requestState,
-                                                                const int8_t& progress,
-                                                                const tFoundMatchesPack& processedMatches) )
-        PUML_METHOD( +, tRequestId requestAnalyze( const tFileWrapperPtr& pFile,
-                                                   const int& fromMessage,
-                                                   const int& numberOfMessages,
-                                                   const QRegularExpression& regex,
-                                                   const int& numberOfThreads,
-                                                   bool isContinuous ) )
+        PUML_PURE_VIRTUAL_METHOD( +, slot void progressNotification( const tProgressNotificationData& progressNotificationData ) )
+        PUML_METHOD( +, tRequestId requestAnalyze( const tRequestParameters& requestParameters ) )
         PUML_AGGREGATION_DEPENDENCY(IDLTMessageAnalyzerController, 1, 1, uses)
         PUML_USE_DEPENDENCY_CHECKED(IFileWrapper, 1, 1, uses)
     PUML_ABSTRACT_CLASS_END()

--- a/dltmessageanalyzerplugin/src/components/filtersView/src/CFiltersModel.cpp
+++ b/dltmessageanalyzerplugin/src/components/filtersView/src/CFiltersModel.cpp
@@ -8,16 +8,16 @@
 #include "QDateTime"
 #include "QRegularExpression"
 
-#ifdef DEBUG_BUILD
-#include "QElapsedTimer"
-#endif
-
 #include "components/settings/api/ISettingsManager.hpp"
 #include "CFiltersModel.hpp"
 #include "components/log/api/CLog.hpp"
 #include "common/PCRE/PCREHelper.hpp"
 
 #include "DMA_Plantuml.hpp"
+
+#ifdef DEBUG_BUILD
+#include "QElapsedTimer"
+#endif
 
 CFiltersModel::CFiltersModel(const tSettingsManagerPtr& pSettingsManager,
                              QObject *parent)

--- a/dltmessageanalyzerplugin/src/components/searchView/src/CSearchResultModel.cpp
+++ b/dltmessageanalyzerplugin/src/components/searchView/src/CSearchResultModel.cpp
@@ -453,9 +453,30 @@ std::pair<int /*rowNumber*/, QString /*diagramContent*/> CSearchResultModel::get
                         }
                         else // otherwise
                         {
-                            // let's directly use client-defined value, ignoring value from the group
-                            UMLRepresentationResult.first = true;
-                            UMLRepresentationResult.second.append(item.UML_Custom_Value);
+                            switch(UML_ID)
+                            {
+                                case eUML_ID::UML_CLIENT:
+                                case eUML_ID::UML_SERVICE:
+                                {
+                                    QString str;
+                                    str.reserve(item.UML_Custom_Value.size() + 2);
+                                    str.append("\"");
+                                    str.append(item.UML_Custom_Value);
+                                    str.append("\"");
+
+                                    // let's directly use client-defined value, ignoring value from the group
+                                    UMLRepresentationResult.first = true;
+                                    UMLRepresentationResult.second.append(str);
+                                }
+                                    break;
+                                default:
+                                {
+                                    // let's directly use client-defined value, ignoring value from the group
+                                    UMLRepresentationResult.first = true;
+                                    UMLRepresentationResult.second.append(item.UML_Custom_Value);
+                                }
+                                    break;
+                            }
                         }
                     }
                 }

--- a/dltmessageanalyzerplugin/src/plugin/api/CDLTMessageAnalyzer.hpp
+++ b/dltmessageanalyzerplugin/src/plugin/api/CDLTMessageAnalyzer.hpp
@@ -225,10 +225,7 @@ signals:
         void tryStop();
 
         // IDLTMessageAnalyzerControllerConsumer interface
-        void progressNotification(const tRequestId &requestId,
-                                  const eRequestState &requestState,
-                                  const int8_t &progress,
-                                  const tFoundMatchesPack &processedMatches);
+        void progressNotification(const tProgressNotificationData& progressNotificationData);
         void animateError( QWidget* pAnimationWidget );
 
         void updateProgress(int progress, eRequestState requestState, bool silent);


### PR DESCRIPTION
## [ISSUE #149] [UML_VIEW] Bug-fixing of the UML view

1. [x] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [x] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows?
4. [x] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Wrapping of all the analyzer's parameters and results into a dedicated structures to increase flexibility of the analyzer API's signature
- Ignore duplicated UEV, URS, URT elements. Apply "first win" strategy in case of found duplicates
- Notify the user about the duplicated UEV, URS, URT elements
- Wrap UCL and US into the "" to allow usage of the wider set of characters
- Fix debug output issue - previous successfully created diagram was printed in debug console instead of the one which contains an error
- Render plantuml error image in the plugin

#### Verification criteria:

- Checked manually on the Windows 10 OS
- All sanity checks on the Git Hub were passed successfully