### PR TITLE
[ISSUE #175] Fix 'convert-txt-to-dlt-file'

### DIFF
--- a/dltmessageanalyzerplugin/src/common/Definitions.hpp
+++ b/dltmessageanalyzerplugin/src/common/Definitions.hpp
@@ -677,16 +677,30 @@ enum class ePathMode
 QString getPathModeAsString(const ePathMode& val);
 
 /**
- * @brief convertLogFileToDLT - converts the content of the sourceFilePath file
- * to the DLT format and saved it to the targetFilePath.
+ * @brief convertLogFileToDLTV1 - converts the content of the sourceFilePath file
+ * to the DLT format and saves it to the targetFilePath.
+ * Uses v1 dlt protocol.
  * Note! Each "\n" separation treated as a new message.
  * @param sourceFilePath - input file path. Should exist
  * @param targetFilePath - output file, which will be created and filled in with content.
  * Note! In case if file under the specified path already exists - it will be truncated!
  * @return - true in case of success. False otherwise.
  */
-bool convertLogFileToDLT( const QString& sourceFilePath,
-                          const QString& targetFilePath );
+bool convertLogFileToDLTV1( const QString& sourceFilePath,
+                           const QString& targetFilePath );
+
+/**
+ * @brief convertLogFileToDLTV2 - converts the content of the sourceFilePath file
+ * to the DLT format and saves it to the targetFilePath.
+ * Uses v2 dlt protocol.
+ * Note! Each "\n" separation treated as a new message.
+ * @param sourceFilePath - input file path. Should exist
+ * @param targetFilePath - output file, which will be created and filled in with content.
+ * Note! In case if file under the specified path already exists - it will be truncated!
+ * @return - true in case of success. False otherwise.
+ */
+bool convertLogFileToDLTV2( const QString& sourceFilePath,
+                           const QString& targetFilePath );
 
 /**
  * @brief isDarkMode - tells whether dark mode is enabled

--- a/dltmessageanalyzerplugin/src/components/log/src/CConsoleInputProcessor.cpp
+++ b/dltmessageanalyzerplugin/src/components/log/src/CConsoleInputProcessor.cpp
@@ -578,12 +578,36 @@ CConsoleInputProcessor::tScenariosMap CConsoleInputProcessor::createScenariosMap
 
                 if(foundTargetFileParam != params.end())
                 {
-                    bool bConvertionResult = convertLogFileToDLT(foundSourceFileParam->second, foundTargetFileParam->second);
+                    bool bConvertionResult = false;
+
+                    auto foundVersionParam = params.find("version");
+
+                    if(foundVersionParam != params.end())
+                    {
+                        if(foundVersionParam->second.toLower() == "v2")
+                        {
+                            bConvertionResult = convertLogFileToDLTV2(foundSourceFileParam->second, foundTargetFileParam->second);
+                        }
+                        else if(foundVersionParam->second.toLower() == "v1")
+                        {
+                            bConvertionResult = convertLogFileToDLTV1(foundSourceFileParam->second, foundTargetFileParam->second);
+                        }
+                        else
+                        {
+                            SEND_ERR(QString("Command [convert-txt-to-dlt-file]: Wrong value '%1' was passed for the parameter 'version'! "
+                                             "Supported values are 'v1' and 'v2'.")
+                                         .arg(foundVersionParam->second));
+                        }
+                    }
+                    else
+                    {
+                        bConvertionResult = convertLogFileToDLTV2(foundSourceFileParam->second, foundTargetFileParam->second);
+                    }
 
                     if(false == bConvertionResult)
                     {
-                       SEND_ERR(QString("Command [convert-txt-to-dlt-file]: Failed to convert the \"%1\" file to dlt format!")
-                                .arg(foundSourceFileParam->second));
+                        SEND_ERR(QString("Command [convert-txt-to-dlt-file]: Failed to convert the \"%1\" file to dlt format!")
+                                     .arg(foundSourceFileParam->second));
                     }
                     else
                     {
@@ -605,9 +629,10 @@ CConsoleInputProcessor::tScenariosMap CConsoleInputProcessor::createScenariosMap
             SEND_ERR("Command [convert-txt-to-dlt-file]: required parameters \"sf\" and \"tf\" not found!");
         }
     },
-    "- converts specified file with '\n' separated set of strings to the dlt format"
+    "- converts specified file with '\\n' separated set of strings to the dlt format"
     "[-sf=<source_file> // mandatory! Source file which we should convert to the dlt format]"
-    "[-tf=<target file> // mandatory! Target file, into which we should save the content]");
+    "[-tf=<target file> // mandatory! Target file, into which we should save the content]"
+    "[-v=<version> // optional! Version of the dlt protocol. Supported values are 'v1' and 'v2'. Default value is 'v2']");
 
     return result;
 }

--- a/md/debug_console/debug_console.md
+++ b/md/debug_console/debug_console.md
@@ -41,7 +41,7 @@ The current set of the supported commands contains:
 | --- | --- | --- |
 | clear | No params | clear debug view |
 | color-aliases | No params | prints all supported color aliases |
-| convert-txt-to-dlt-file | [-sf=<source_file> // mandatory! Source file which we should convert to the dlt format][-tf=<target file> // mandatory! Target file, into which we should save the content] | converts specified file with '\n' separated set of strings to the dlt format
+| convert-txt-to-dlt-file | [-sf=<source_file> // mandatory! Source file which we should convert to the dlt format][-tf=<target file> // mandatory! Target file, into which we should save the content][-v=<version> // optional! Version of the dlt protocol. Supported values are 'v1' and 'v2'. Default value is 'v2'] | converts specified file with '\n' separated set of strings to the dlt format
 | help | [-c=&lt;command-name&gt;] | show this help. If no "c" parameter is provided - help regarding all available commands will be dumped. Be aware, that [&lt;command-name&gt; &lt;help&gt;] syntax can also be used to get the help output regarding a single command. Such syntax is easier to use, considering the limited auto-complete functionality of this console. E.g. "help -help" (ha-ha). |
 | plantuml-settings | No params | prints information about the currently used plantuml settings |
 | styles | No params | prints information about QT styles supported on target OS |


### PR DESCRIPTION
## [ISSUE #175] Fix 'convert-txt-to-dlt-file'

1. [x] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows? Checked only on Linux.
4. [x] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Fixed bugs in the 'convert-txt-to-dlt-file'
- Added support of the v2 dlt protocol to that functionality
- Added parameter to allow selecting in which way to form the dlt file

#### Verification criteria:

- v1 and v2 algorithms were both checked on Ubuntu. Should work in the same on Windows OS.