### PR TITLE
[ISSUE #180][BUILD] CMake failure with QT < 5.15.0

### DIFF
--- a/dltmessageanalyzerplugin/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/CMakeLists.txt
@@ -3,6 +3,35 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 ################### CPP ( END ) ###########################
 
+################### QT_SPECIFIC ###########################
+if(${QT_PREFIX}Core_VERSION VERSION_LESS "5.15.0")
+    message("DMA_QT5_COMPATIBILITY_MODE is set")
+    set(DMA_QT5_COMPATIBILITY_MODE TRUE)
+else()
+    set(DMA_QT5_COMPATIBILITY_MODE FALSE)
+endif()
+
+function (DMA_qt_wrap_cpp processed_mocs_var_name wrap_src_var_name)
+    set(local_processed_mocs)
+    if(DMA_QT5_COMPATIBILITY_MODE)
+      qt5_wrap_cpp(local_processed_mocs ${${wrap_src_var_name}})
+    else()
+      qt_wrap_cpp(local_processed_mocs ${${wrap_src_var_name}})
+    endif()
+    set(${processed_mocs_var_name} ${local_processed_mocs} PARENT_SCOPE)
+endfunction()
+
+function (DMA_QT_WRAP_UI ui_headers_var_name wrap_ui_var_name)
+    set(local_ui_headers)
+    if(DMA_QT5_COMPATIBILITY_MODE)
+      QT5_WRAP_UI(local_ui_headers ${${wrap_ui_var_name}})
+    else()
+      QT_WRAP_UI(local_ui_headers ${${wrap_ui_var_name}})
+    endif()
+    set(${ui_headers_var_name} ${local_ui_headers} PARENT_SCOPE)
+endfunction()
+################### QT_SPECIFIC ( END ) ###################
+
 ################### COMMON_DEPS ###########################
 include(FetchContent)
 FetchContent_Declare(

--- a/dltmessageanalyzerplugin/src/components/analyzer/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/components/analyzer/src/CMakeLists.txt
@@ -1,6 +1,7 @@
-qt_wrap_cpp(PROCESSED_MOCS
-             ../api/IDLTMessageAnalyzerControllerConsumer.hpp
+set(WRAP_SRC ../api/IDLTMessageAnalyzerControllerConsumer.hpp
              ../api/IDLTMessageAnalyzerController.hpp)
+
+DMA_qt_wrap_cpp(PROCESSED_MOCS WRAP_SRC)
 
 add_library(DMA_analyzer STATIC
     IDLTMessageAnalyzerController.cpp

--- a/dltmessageanalyzerplugin/src/components/filtersView/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/components/filtersView/src/CMakeLists.txt
@@ -1,6 +1,7 @@
-qt_wrap_cpp(PROCESSED_MOCS
-             ../api/CFiltersView.hpp
+set(WRAP_SRC ../api/CFiltersView.hpp
              ../api/IFiltersModel.hpp)
+
+DMA_qt_wrap_cpp(PROCESSED_MOCS WRAP_SRC)
 
 add_library(DMA_filtersView STATIC
     CFiltersModel.cpp

--- a/dltmessageanalyzerplugin/src/components/groupedView/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/components/groupedView/src/CMakeLists.txt
@@ -1,5 +1,6 @@
-qt_wrap_cpp(PROCESSED_MOCS
-             ../api/CGroupedView.hpp)
+set(WRAP_SRC ../api/CGroupedView.hpp)
+
+DMA_qt_wrap_cpp(PROCESSED_MOCS WRAP_SRC)
 
 add_library(DMA_groupedView STATIC
     CGroupedView.cpp

--- a/dltmessageanalyzerplugin/src/components/log/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/components/log/src/CMakeLists.txt
@@ -1,5 +1,6 @@
-qt_wrap_cpp(PROCESSED_MOCS
-             ../api/CConsoleView.hpp)
+set(WRAP_SRC ../api/CConsoleView.hpp)
+
+DMA_qt_wrap_cpp(PROCESSED_MOCS WRAP_SRC)
 
 add_library(DMA_log STATIC
     CConsoleCtrl.cpp

--- a/dltmessageanalyzerplugin/src/components/logo/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/components/logo/src/CMakeLists.txt
@@ -1,5 +1,6 @@
-qt_wrap_cpp(PROCESSED_MOCS
-             ../api/CLogo.hpp)
+set(WRAP_SRC ../api/CLogo.hpp)
+
+DMA_qt_wrap_cpp(PROCESSED_MOCS WRAP_SRC)
 
 add_library(DMA_logo STATIC
     CLogo.cpp

--- a/dltmessageanalyzerplugin/src/components/logsWrapper/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/components/logsWrapper/src/CMakeLists.txt
@@ -1,5 +1,6 @@
-qt_wrap_cpp(PROCESSED_MOCS
-             ../api/IFileWrapper.hpp)
+set(WRAP_SRC ../api/IFileWrapper.hpp)
+
+DMA_qt_wrap_cpp(PROCESSED_MOCS WRAP_SRC)
 
 add_library(DMA_logsWrapper STATIC
     CDLTFileWrapper.cpp

--- a/dltmessageanalyzerplugin/src/components/patternsView/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/components/patternsView/src/CMakeLists.txt
@@ -1,6 +1,7 @@
-qt_wrap_cpp(PROCESSED_MOCS
-             ../api/IPatternsModel.hpp
+set(WRAP_SRC ../api/IPatternsModel.hpp
              ../api/CPatternsView.hpp)
+
+DMA_qt_wrap_cpp(PROCESSED_MOCS WRAP_SRC)
 
 add_library(DMA_patternsView STATIC
     CPatternsModel.cpp

--- a/dltmessageanalyzerplugin/src/components/plant_uml/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/components/plant_uml/src/CMakeLists.txt
@@ -1,5 +1,6 @@
-qt_wrap_cpp(PROCESSED_MOCS
-             ../api/CUMLView.hpp)
+set(WRAP_SRC ../api/CUMLView.hpp)
+
+DMA_qt_wrap_cpp(PROCESSED_MOCS WRAP_SRC)
 
 add_library(DMA_plant_uml STATIC
 #   CSVGView.cpp

--- a/dltmessageanalyzerplugin/src/components/searchView/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/components/searchView/src/CMakeLists.txt
@@ -1,6 +1,7 @@
-qt_wrap_cpp(PROCESSED_MOCS
-             ../api/CSearchResultView.hpp
+set(WRAP_SRC ../api/CSearchResultView.hpp
              ../api/CSearchViewComponent.hpp)
+
+DMA_qt_wrap_cpp(PROCESSED_MOCS WRAP_SRC)
 
 add_library(DMA_searchView STATIC
     CSearchResultHighlightingDelegate.cpp

--- a/dltmessageanalyzerplugin/src/components/settings/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/components/settings/src/CMakeLists.txt
@@ -1,5 +1,6 @@
-qt_wrap_cpp(PROCESSED_MOCS
-             ../api/ISettingsManager.hpp)
+set(WRAP_SRC ../api/ISettingsManager.hpp)
+
+DMA_qt_wrap_cpp(PROCESSED_MOCS WRAP_SRC)
 
 add_library(DMA_settings STATIC
     CSettingsManager.cpp

--- a/dltmessageanalyzerplugin/src/plugin/src/CMakeLists.txt
+++ b/dltmessageanalyzerplugin/src/plugin/src/CMakeLists.txt
@@ -1,8 +1,9 @@
-QT_WRAP_UI( UI_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/form.ui )
-
-qt_wrap_cpp(PROCESSED_MOCS
-             ../api/form.h
+set(WRAP_SRC ../api/form.h
              ../api/CDLTMessageAnalyzer.hpp)
+DMA_qt_wrap_cpp(PROCESSED_MOCS WRAP_SRC)
+
+set(WRAP_UI ${CMAKE_CURRENT_SOURCE_DIR}/form.ui)
+DMA_QT_WRAP_UI(UI_HEADERS WRAP_UI)
 
 add_library(DMA_plugin STATIC
     CDLTMessageAnalyzer.cpp


### PR DESCRIPTION
## [ISSUE #180][BUILD] CMake failure with QT < 5.15.0

1. [X] Have you followed the guidelines in our [Contributing document](../blob/master/CONTRIBUTING.md)?
2. [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
3. [] Have you built the project, and performed manual testing of your functionality for all supported platforms - Linux and Windows? Checked on Ubuntu only.
4. [X] Is your change backward-compatible with the previous version of the plugin?

#### Change description:

- Added glue code to call compatible qt CMake commands in case of Qt version < 5.15.0

#### Verification criteria:

- Checked manually on Ubuntu OS