### PR TITLE
[ISSUE #188][FILES_VIEW] Update implementation of the 'CDLTFileItem::updateIndex'

### DIFF
--- a/dltmessageanalyzerplugin/src/common/PlotDefinitions.cpp
+++ b/dltmessageanalyzerplugin/src/common/PlotDefinitions.cpp
@@ -720,7 +720,7 @@ static tPlotViewIDsMap createPlotIDsMap()
         item.id_type = ePlotViewIDType::e_Mandatory_Gantt;
         item.id_str = s_PLOT_GANTT_EVENT;
         formGanttParameters(item);
-        item.description = QString("Declares event of a certain type ( either \"start\" or \"end\" ). "
+        item.description = QString("Declares event of a certain type ( either \"start\" or \"end\" ). %1."
                                    "Used to identify start and end points of different events, which should "
                                    "be represented on the Gantt chart. "
                                    "Mandatory. One or more.").arg(item.getParametersDescription());

--- a/dltmessageanalyzerplugin/src/components/analyzer/src/CMTAnalyzer.cpp
+++ b/dltmessageanalyzerplugin/src/components/analyzer/src/CMTAnalyzer.cpp
@@ -198,19 +198,22 @@ bool CMTAnalyzer::regexAnalysisIteration(tRequestMap::iterator& inputIt, const t
 
                         auto pStringData = getDataStrFromMsg(msgIdx, pMsg, *iter);
 
-                        pStr->append(*pStringData);
-                        newRangeCounter += pStringData->size() - 1;
-
-                        if (std::next(iter) != searchColumnsSet.end())
+                        if(nullptr != pStringData)
                         {
-                            pStr->append(" ");
-                            newRangeCounter += 2;
+                            pStr->append(*pStringData);
+                            newRangeCounter += pStringData->size() - 1;
+
+                            if (std::next(iter) != searchColumnsSet.end())
+                            {
+                                pStr->append(" ");
+                                newRangeCounter += 2;
+                            }
+
+                            tIntRange strRange(rangeCounter, rangeCounter + pStringData->size() - 1);
+                            fieldRanges.insert(*iter, strRange);
+
+                            rangeCounter = newRangeCounter;
                         }
-
-                        tIntRange strRange(rangeCounter, rangeCounter + pStringData->size() - 1);
-                        fieldRanges.insert(*iter, strRange);
-
-                        rangeCounter = newRangeCounter;
                     }
 
                     tItemMetadata itemMetadata( msgIdx,

--- a/dltmessageanalyzerplugin/src/components/searchView/src/CSearchResultView.cpp
+++ b/dltmessageanalyzerplugin/src/components/searchView/src/CSearchResultView.cpp
@@ -907,7 +907,7 @@ void CSearchResultView::copyMessageFiles()
             else if(selectedRowsSize == 1)
             {
                 auto selectedRowModelIdx = selectedRows.front();
-                auto selectedRowIdx = selectedRowModelIdx.sibling(selectedRowModelIdx.row(), static_cast<int>(eSearchResultColumn::UML_Applicability)).data().value<int>();
+                auto selectedRowIdx = selectedRowModelIdx.sibling(selectedRowModelIdx.row(), static_cast<int>(eSearchResultColumn::Index)).data().value<int>();
 
                 mpFile->copyFileNameToClipboard(selectedRowIdx);
             }


### PR DESCRIPTION
## [ISSUE #188][FILES_VIEW] Update implementation of the 'CDLTFileItem::updateIndex'

#### Change description:

- Updated implementation of the 'CDLTFileItem::updateIndex'
- Added nullptr check to the CMTAnalyzer
- Fixed warning with the missing parameter in QString::arg call

----

#### Verification criteria:

- Fix was verified on the Linux