### PR TITLE
[ISSUE #63] Attach build artifacts to releases

### DIFF
--- a/.github/workflows/build_linux_qt5.yml
+++ b/.github/workflows/build_linux_qt5.yml
@@ -16,6 +16,13 @@ on:
         required: false
         default: 'false'
         type: boolean
+  workflow_call:
+    inputs:
+      collect_artifacts:
+        description: 'Collect build artifacts'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build_linux:
@@ -95,7 +102,7 @@ jobs:
 
     # Collect required artifacts
     - name: Collect required artifacts
-      if: ${{ success() && github.event.inputs.collect_artifacts == 'true' }}
+      if: ${{ success() && inputs.collect_artifacts }}
       run: |
         set -euo pipefail
 
@@ -175,7 +182,7 @@ jobs:
       working-directory: ./
 
     - name: Upload artifacts
-      if: ${{ success() && github.event.inputs.collect_artifacts == 'true' }}
+      if: ${{ success() && inputs.collect_artifacts }}
       uses: actions/upload-artifact@v4
       with:
         name: release_linux_qt5_X86_64

--- a/.github/workflows/build_linux_qt6.yml
+++ b/.github/workflows/build_linux_qt6.yml
@@ -16,6 +16,13 @@ on:
         required: false
         default: 'false'
         type: boolean
+  workflow_call:
+    inputs:
+      collect_artifacts:
+        description: 'Collect build artifacts'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build_linux:
@@ -96,7 +103,7 @@ jobs:
 
     # Collect required artifacts
     - name: Collect required artifacts
-      if: ${{ success() && github.event.inputs.collect_artifacts == 'true' }}
+      if: ${{ success() && inputs.collect_artifacts }}
       run: |
         set -euo pipefail
 
@@ -176,7 +183,7 @@ jobs:
       working-directory: ./
 
     - name: Upload artifacts
-      if: ${{ success() && github.event.inputs.collect_artifacts == 'true' }}
+      if: ${{ success() && inputs.collect_artifacts }}
       uses: actions/upload-artifact@v4
       with:
         name: release_linux_qt6_X86_64

--- a/.github/workflows/build_windows_qt5.yml
+++ b/.github/workflows/build_windows_qt5.yml
@@ -16,6 +16,13 @@ on:
         required: false
         default: 'false'
         type: boolean
+  workflow_call:
+    inputs:
+      collect_artifacts:
+        description: 'Collect build artifacts'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build_windows:
@@ -115,7 +122,7 @@ jobs:
 
     # Collect required artifacts
     - name: Collect required artifacts
-      if: ${{ github.event.inputs.collect_artifacts == 'true' }}
+      if: ${{ inputs.collect_artifacts }}
       run: |
         mkdir .\release_win_qt5_X86_64
         mkdir .\release_win_qt5_X86_64\plugins
@@ -154,7 +161,7 @@ jobs:
       working-directory: .\
 
     - name: Upload artifacts
-      if: ${{ success() && github.event.inputs.collect_artifacts == 'true' }}
+      if: ${{ success() && inputs.collect_artifacts }}
       uses: actions/upload-artifact@v4
       with:
         name: release_win_qt5_X86_64

--- a/.github/workflows/build_windows_qt6.yml
+++ b/.github/workflows/build_windows_qt6.yml
@@ -16,6 +16,13 @@ on:
         required: false
         default: 'false'
         type: boolean
+  workflow_call:
+    inputs:
+      collect_artifacts:
+        description: 'Collect build artifacts'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build_windows:
@@ -117,7 +124,7 @@ jobs:
 
     # Collect required artifacts
     - name: Collect required artifacts
-      if: ${{ github.event.inputs.collect_artifacts == 'true' }}
+      if: ${{ inputs.collect_artifacts }}
       run: |
         mkdir .\release_win_qt6_X86_64
         mkdir .\release_win_qt6_X86_64\plugins
@@ -156,7 +163,7 @@ jobs:
       working-directory: .\
 
     - name: Upload artifacts
-      if: ${{ success() && github.event.inputs.collect_artifacts == 'true' }}
+      if: ${{ success() && inputs.collect_artifacts }}
       uses: actions/upload-artifact@v4
       with:
         name: release_win_qt6_X86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release artifacts
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Existing release tag to upload artifacts to'
+        required: true
+
+jobs:
+  build_windows_qt5:
+    uses: ./.github/workflows/build_windows_qt5.yml
+    with:
+      collect_artifacts: true
+
+  build_windows_qt6:
+    uses: ./.github/workflows/build_windows_qt6.yml
+    with:
+      collect_artifacts: true
+
+  build_linux_qt5:
+    uses: ./.github/workflows/build_linux_qt5.yml
+    with:
+      collect_artifacts: true
+
+  build_linux_qt6:
+    uses: ./.github/workflows/build_linux_qt6.yml
+    with:
+      collect_artifacts: true
+
+  publish:
+    needs:
+      - build_windows_qt5
+      - build_windows_qt6
+      - build_linux_qt5
+      - build_linux_qt6
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release_artifacts
+
+      - name: Package artifacts
+        run: |
+          set -euo pipefail
+
+          mkdir -p packaged
+
+          package_zip() {
+            local artifact="$1"
+            test -d "release_artifacts/${artifact}"
+            (
+              cd "release_artifacts/${artifact}"
+              zip -r "../../packaged/${artifact}.zip" .
+            )
+          }
+
+          package_tar() {
+            local artifact="$1"
+            test -d "release_artifacts/${artifact}"
+            tar -czf "packaged/${artifact}.tar.gz" -C "release_artifacts/${artifact}" .
+          }
+
+          package_zip "release_win_qt5_X86_64"
+          package_zip "release_win_qt6_X86_64"
+          package_tar "release_linux_qt5_X86_64"
+          package_tar "release_linux_qt6_X86_64"
+
+      - name: Upload artifacts to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+        run: gh release upload "${RELEASE_TAG}" packaged/* --clobber


### PR DESCRIPTION
Expose existing Qt5 and Qt6 build workflows as reusable workflows with
the artifact collection input.

Add a release workflow that reuses those builds, packages the uploaded
artifacts, and attaches them to the GitHub Release.