### PR TITLE
[ISSUE #63] Pass repository to release upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,4 +76,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
-        run: gh release upload "${RELEASE_TAG}" packaged/* --clobber
+        run: gh release upload "${RELEASE_TAG}" packaged/* --repo "${GITHUB_REPOSITORY}" --clobber


### PR DESCRIPTION
Pass the repository explicitly when uploading release assets so the publish job does not require a checked-out git repository.